### PR TITLE
moved `name` to `default.name`

### DIFF
--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -58,7 +58,7 @@ function getInitialLabel(record) {
     return [];
   }
 
-  return [record.name];
+  return [record.name.default];
 
 }
 

--- a/test/labelGenerator_AUS.js
+++ b/test/labelGenerator_AUS.js
@@ -12,7 +12,7 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.australia = function(test, common) {
   test('venue', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -32,7 +32,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('localadmin value should be used when locality is not available', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -51,7 +51,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('street', function(t) {
     var doc = {
-      'name': 'house number street name',
+      'name': { 'default': 'house number street name' },
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
@@ -71,7 +71,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('neighbourhood', function(t) {
     var doc = {
-      'name': 'neighbourhood name',
+      'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
       'neighbourhood': 'neighbourhood name',
       'locality': 'locality name',
@@ -89,7 +89,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('locality', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'layer': 'locality',
       'locality': 'locality name',
       'localadmin': 'localadmin name',
@@ -106,7 +106,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('localadmin', function(t) {
     var doc = {
-      'name': 'localadmin name',
+      'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
       'localadmin': 'localadmin name',
       'county': 'county name',
@@ -122,7 +122,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('county', function(t) {
     var doc = {
-      'name': 'county name',
+      'name': { 'default': 'county name' },
       'layer': 'county',
       'county': 'county name',
       'macrocounty': 'macrocounty name',
@@ -137,7 +137,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('macrocounty', function(t) {
     var doc = {
-      'name': 'macrocounty name',
+      'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
       'macrocounty': 'macrocounty name',
       'region': 'region name',
@@ -151,7 +151,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('region', function(t) {
     var doc = {
-      'name': 'region name',
+      'name': { 'default': 'region name' },
       'layer': 'region',
       'region': 'region name',
       'macroregion': 'macroregion name',
@@ -164,7 +164,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('macroregion', function(t) {
     var doc = {
-      'name': 'macroregion name',
+      'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
       'macroregion': 'macroregion name',
       'country_a': 'AUS',
@@ -176,7 +176,7 @@ module.exports.tests.australia = function(test, common) {
 
   test('country', function(t) {
     var doc = {
-      'name': 'Australia',
+      'name': { 'default': 'Australia' },
       'layer': 'country',
       'postalcode': 'postalcode',
       'country_a': 'AUS',

--- a/test/labelGenerator_CAN.js
+++ b/test/labelGenerator_CAN.js
@@ -12,7 +12,7 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.canada = function(test, common) {
   test('venue', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -33,7 +33,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('street', function(t) {
     var doc = {
-      'name': 'house number street name',
+      'name': { 'default': 'house number street name' },
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
@@ -54,7 +54,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('neighbourhood', function(t) {
     var doc = {
-      'name': 'neighbourhood name',
+      'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
       'neighbourhood': 'neighbourhood name',
       'locality': 'locality name',
@@ -73,7 +73,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('locality', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'layer': 'locality',
       'locality': 'locality name',
       'localadmin': 'localadmin name',
@@ -91,7 +91,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('localadmin', function(t) {
     var doc = {
-      'name': 'localadmin name',
+      'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
       'localadmin': 'localadmin name',
       'county': 'county name',
@@ -108,7 +108,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('county', function(t) {
     var doc = {
-      'name': 'county name',
+      'name': { 'default': 'county name' },
       'layer': 'county',
       'county': 'county name',
       'macrocounty': 'macrocounty name',
@@ -124,7 +124,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('macrocounty', function(t) {
     var doc = {
-      'name': 'macrocounty name',
+      'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
       'macrocounty': 'macrocounty name',
       'region_a': 'region abbr',
@@ -139,7 +139,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('region', function(t) {
     var doc = {
-      'name': 'region name',
+      'name': { 'default': 'region name' },
       'layer': 'region',
       'region_a': 'region abbr',
       'region': 'region name',
@@ -153,7 +153,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('macroregion', function(t) {
     var doc = {
-      'name': 'macroregion name',
+      'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
       'macroregion': 'macroregion name',
       'country_a': 'CAN',
@@ -165,7 +165,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('country', function(t) {
     var doc = {
-      'name': 'Canada',
+      'name': { 'default': 'Canada' },
       'layer': 'country',
       'country_a': 'CAN',
       'country': 'Canada'
@@ -176,7 +176,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('region should be used when region_a is not available', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'layer': 'region',
       'locality': 'locality name',
       'localadmin': 'localadmin name',

--- a/test/labelGenerator_GBR.js
+++ b/test/labelGenerator_GBR.js
@@ -12,7 +12,7 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.united_kingdom = function(test, common) {
   test('venue', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -32,7 +32,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('localadmin value should be used when locality is not available', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -51,7 +51,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('street', function(t) {
     var doc = {
-      'name': 'house number street name',
+      'name': { 'default': 'house number street name' },
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
@@ -71,7 +71,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('neighbourhood', function(t) {
     var doc = {
-      'name': 'neighbourhood name',
+      'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
       'neighbourhood': 'neighbourhood name',
       'locality': 'locality name',
@@ -89,7 +89,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('locality', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'layer': 'locality',
       'locality': 'locality name',
       'localadmin': 'localadmin name',
@@ -106,7 +106,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('localadmin', function(t) {
     var doc = {
-      'name': 'localadmin name',
+      'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
       'localadmin': 'localadmin name',
       'county': 'county name',
@@ -122,7 +122,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('county', function(t) {
     var doc = {
-      'name': 'county name',
+      'name': { 'default': 'county name' },
       'layer': 'county',
       'county': 'county name',
       'macrocounty': 'macrocounty name',
@@ -137,7 +137,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('macrocounty', function(t) {
     var doc = {
-      'name': 'macrocounty name',
+      'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
       'macrocounty': 'macrocounty name',
       'region': 'region name',
@@ -151,7 +151,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('region', function(t) {
     var doc = {
-      'name': 'region name',
+      'name': { 'default': 'region name' },
       'layer': 'region',
       'region': 'region name',
       'macroregion': 'macroregion name',
@@ -164,7 +164,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('macroregion', function(t) {
     var doc = {
-      'name': 'macroregion name',
+      'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
       'macroregion': 'macroregion name',
       'country_a': 'GBR',
@@ -176,7 +176,7 @@ module.exports.tests.united_kingdom = function(test, common) {
 
   test('country', function(t) {
     var doc = {
-      'name': 'United Kingdom',
+      'name': { 'default': 'United Kingdom' },
       'layer': 'country',
       'postalcode': 'postalcode',
       'country_a': 'GBR',

--- a/test/labelGenerator_USA.js
+++ b/test/labelGenerator_USA.js
@@ -12,7 +12,7 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.united_states = function(test, common) {
   test('venue', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -33,7 +33,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('localadmin value should be used when there is no locality', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -53,7 +53,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('county value should be used when there is no localadmin', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -72,7 +72,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('street', function(t) {
     var doc = {
-      'name': 'house number street name',
+      'name': { 'default': 'house number street name' },
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
@@ -93,7 +93,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('neighbourhood', function(t) {
     var doc = {
-      'name': 'neighbourhood name',
+      'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
       'neighbourhood': 'neighbourhood name',
       'locality': 'locality name',
@@ -112,7 +112,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('venue in borough', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'borough',
       'neighbourhood': 'neighbourhood name',
       'borough': 'borough name',
@@ -132,7 +132,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('locality', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'layer': 'locality',
       'locality': 'locality name',
       'localadmin': 'localadmin name',
@@ -150,7 +150,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('localadmin', function(t) {
     var doc = {
-      'name': 'localadmin name',
+      'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
       'localadmin': 'localadmin name',
       'county': 'county name',
@@ -167,7 +167,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('county', function(t) {
     var doc = {
-      'name': 'county name',
+      'name': { 'default': 'county name' },
       'layer': 'county',
       'county': 'county name',
       'macrocounty': 'macrocounty name',
@@ -183,7 +183,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('macrocounty', function(t) {
     var doc = {
-      'name': 'macrocounty name',
+      'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
       'macrocounty': 'macrocounty name',
       'region_a': 'region abbr',
@@ -198,7 +198,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('region', function(t) {
     var doc = {
-      'name': 'region name',
+      'name': { 'default': 'region name' },
       'layer': 'region',
       'region_a': 'region abbr',
       'region': 'region name',
@@ -212,7 +212,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('macroregion', function(t) {
     var doc = {
-      'name': 'macroregion name',
+      'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
       'macroregion': 'macroregion name',
       'country_a': 'USA',
@@ -224,7 +224,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('country', function(t) {
     var doc = {
-      'name': 'United States',
+      'name': { 'default': 'United States' },
       'layer': 'country',
       'country_a': 'USA',
       'country': 'United States'
@@ -235,7 +235,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('region should be used when region_a is not available', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'locality': 'locality name',
       'localadmin': 'localadmin name',
       'county': 'county name',
@@ -251,7 +251,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('dependency layer should use full name instead of abbreviation', function(t) {
     var doc = {
-      'name': 'dependency name',
+      'name': { 'default': 'dependency name' },
       'layer': 'dependency',
       'dependency_a': 'dependency abbr',
       'dependency': 'dependency name',
@@ -265,7 +265,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('dependency abbreviation should be used instead of dependency name or country and skip region', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'locality': 'locality name',
       'localadmin': 'localadmin name',
       'county': 'county name',
@@ -284,7 +284,7 @@ module.exports.tests.united_states = function(test, common) {
 
   test('dependency name should be used instead of country when dep abbr is unavailable and skip region', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'locality': 'locality name',
       'localadmin': 'localadmin name',
       'county': 'county name',

--- a/test/labelGenerator_default.js
+++ b/test/labelGenerator_default.js
@@ -12,7 +12,7 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.default_country = function(test, common) {
   test('venue', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -32,7 +32,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('localadmin value should be used when locality is not available', function(t) {
     var doc = {
-      'name': 'venue name',
+      'name': { 'default': 'venue name' },
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
@@ -51,7 +51,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('street', function(t) {
     var doc = {
-      'name': 'house number street name',
+      'name': { 'default': 'house number street name' },
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
@@ -71,7 +71,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('neighbourhood', function(t) {
     var doc = {
-      'name': 'neighbourhood name',
+      'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
       'neighbourhood': 'neighbourhood name',
       'locality': 'locality name',
@@ -89,7 +89,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('locality', function(t) {
     var doc = {
-      'name': 'locality name',
+      'name': { 'default': 'locality name' },
       'layer': 'locality',
       'locality': 'locality name',
       'localadmin': 'localadmin name',
@@ -106,7 +106,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('localadmin', function(t) {
     var doc = {
-      'name': 'localadmin name',
+      'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
       'localadmin': 'localadmin name',
       'county': 'county name',
@@ -122,7 +122,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('county', function(t) {
     var doc = {
-      'name': 'county name',
+      'name': { 'default': 'county name' },
       'layer': 'county',
       'county': 'county name',
       'macrocounty': 'macrocounty name',
@@ -137,7 +137,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('macrocounty', function(t) {
     var doc = {
-      'name': 'macrocounty name',
+      'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
       'macrocounty': 'macrocounty name',
       'region': 'region name',
@@ -151,7 +151,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('region', function(t) {
     var doc = {
-      'name': 'region name',
+      'name': { 'default': 'region name' },
       'layer': 'region',
       'region': 'region name',
       'macroregion': 'macroregion name',
@@ -164,7 +164,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('macroregion', function(t) {
     var doc = {
-      'name': 'macroregion name',
+      'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
       'macroregion': 'macroregion name',
       'country_a': 'country code',
@@ -176,7 +176,7 @@ module.exports.tests.default_country = function(test, common) {
 
   test('country layer labels should only use the `country` field and not the `name`', function(t) {
     var doc = {
-      'name': 'source country name',
+      'name': { 'default': 'source country name' },
       'layer': 'country',
       'country_a': 'country code',
       'country': 'hierarchy country name'

--- a/test/labelGenerator_examples.js
+++ b/test/labelGenerator_examples.js
@@ -12,7 +12,7 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.canada = function(test, common) {
   test('venue', function(t) {
     var doc = {
-      'name': 'Tim Horton\'s',
+      'name': { 'default': 'Tim Horton\'s'},
       'layer': 'venue',
       'housenumber': '1',
       'street': 'Main St',
@@ -29,7 +29,7 @@ module.exports.tests.canada = function(test, common) {
 
   test('address', function(t) {
     var doc = {
-      'name': '1 Main St',
+      'name': { 'default': '1 Main St'},
       'layer': 'venue',
       'housenumber': '1',
       'street': 'Main St',
@@ -47,7 +47,7 @@ module.exports.tests.canada = function(test, common) {
 module.exports.tests.france = function(test, common) {
   test('eiffel tower', function(t) {
     var doc = {
-      'name': 'Tour Eiffel',
+      'name': { 'default': 'Tour Eiffel'},
       'layer': 'venue',
       'neighbourhood': 'Quartier du Gros-Caillou',
       'locality': 'Paris',
@@ -61,7 +61,7 @@ module.exports.tests.france = function(test, common) {
 
   test('France street address', function(t) {
     var doc = {
-      'name': '74 rue de rivoli',
+      'name': { 'default': '74 rue de rivoli'},
       'layer': 'address',
       'housenumber': '74',
       'street': 'Rue de Rivoli',
@@ -77,7 +77,7 @@ module.exports.tests.france = function(test, common) {
 
   test('France neighbourhood', function(t) {
     var doc = {
-      'name': 'Grange aux Belles Terrage',
+      'name': { 'default': 'Grange aux Belles Terrage'},
       'layer': 'neighbourhood',
       'neighbourhood': 'Grange aux Belles Terrage',
       'locality': 'Paris',
@@ -91,7 +91,7 @@ module.exports.tests.france = function(test, common) {
 
   test('Luxembourg (the city) in Luxembourg', function(t) {
     var doc = {
-      'name': 'Luxembourg',
+      'name': { 'default': 'Luxembourg'},
       'layer': 'locality',
       'locality': 'Luxembourg',
       'country_a': 'LUX',
@@ -107,7 +107,9 @@ module.exports.tests.france = function(test, common) {
 module.exports.tests.name_only = function(test, common) {
   test('name-only results (no admin fields) should not include extraneous comma', function(t) {
     var doc = {
-      'name': 'Result name',
+      'name': {
+        'default': 'Result name'
+      }
     };
     t.equal(generator(doc),'Result name');
     t.end();


### PR DESCRIPTION
Now that label generation is pre-geojsonify in api, the name comes from `name.default`, not just `name`.  