### PR TITLE
moved to arrays for admin fields

### DIFF
--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -19,8 +19,8 @@ function dedupeNameAndFirstLabelElement(labelParts) {
 }
 
 function getSchema(country_a) {
-  if (country_a && country_a.length && schemas[country_a]) {
-    return schemas[country_a];
+  if (!_.isEmpty(schemas[country_a])) {
+    return schemas[country_a[0]];
   }
 
   return schemas.default;
@@ -50,7 +50,7 @@ function isGeonamesOrWhosOnFirst(source) {
 function getInitialLabel(record) {
   if (isRegion(record.layer) &&
       isGeonamesOrWhosOnFirst(record.source) &&
-      isUSAOrCAN(record.country_a)) {
+      isUSAOrCAN(record.country_a[0])) {
     return [];
   }
 

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -7,7 +7,7 @@ function getFirstProperty(fields) {
       var fieldValue = record[fields[i]];
 
       if (!_.isEmpty(fieldValue)) {
-        return fieldValue;
+        return fieldValue[0];
       }
 
     }
@@ -23,21 +23,21 @@ function getFirstProperty(fields) {
 // 3.  otherwise, the state/province abbreviation should be used, eg: Lancaster, PA, USA and Bruce, ON, CA
 // 4.  if the abbreviation isn't available, use the full state/province name
 function getRegionalValue(record) {
-  if (record.hasOwnProperty('dependency') || record.hasOwnProperty('dependency_a')) {
+  if (!_.isEmpty(record.dependency) || !_.isEmpty(record.dependency_a)) {
     return;
   }
 
-  if ('region' === record.layer && record.region) {
+  if ('region' === record.layer && !_.isEmpty(record.region)) {
     // return full state name when state is the most granular piece of info
-    return record.region;
+    return record.region[0];
 
-  } else if (record.region_a) {
+  } else if (!_.isEmpty(record.region_a)) {
     // otherwise just return the region code when available
-    return record.region_a;
+    return record.region_a[0];
 
-  } else if (record.region) {
+  } else if (!_.isEmpty(record.region)) {
     // return the full name when there's no region code available
-    return record.region;
+    return record.region[0];
 
   }
 
@@ -50,19 +50,19 @@ function getRegionalValue(record) {
 // 4.  use dependency name if no abbreviation, eg - San Juan, Puerto Rico
 // 5.  use country abbreviation, eg - Lancaster, PA, USA
 function getUSADependencyOrCountryValue(record) {
-  if ('dependency' === record.layer && record.hasOwnProperty('dependency')) {
-    return record.dependency;
-  } else if ('country' === record.layer && record.hasOwnProperty('country')) {
-    return record.country;
+  if ('dependency' === record.layer && !_.isEmpty(record.dependency)) {
+    return record.dependency[0];
+  } else if ('country' === record.layer && !_.isEmpty(record.country)) {
+    return record.country[0];
   }
 
-  if (record.hasOwnProperty('dependency_a')) {
-    return record.dependency_a;
-  } else if (record.hasOwnProperty('dependency')) {
-    return record.dependency;
+  if (!_.isEmpty(record.dependency_a)) {
+    return record.dependency_a[0];
+  } else if (!_.isEmpty(record.dependency)) {
+    return record.dependency[0];
   }
 
-  return record.country_a;
+  return record.country_a[0];
 }
 
 module.exports = {

--- a/test/labelGenerator_AUS.js
+++ b/test/labelGenerator_AUS.js
@@ -16,15 +16,15 @@ module.exports.tests.australia = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'venue name, locality name, region name, Australia');
     t.end();
@@ -36,14 +36,14 @@ module.exports.tests.australia = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'neighbourhood': ['neighbourhood name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'venue name, localadmin name, region name, Australia');
     t.end();
@@ -55,15 +55,15 @@ module.exports.tests.australia = function(test, common) {
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'house number street name, locality name, region name, Australia');
     t.end();
@@ -73,15 +73,15 @@ module.exports.tests.australia = function(test, common) {
     var doc = {
       'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'neighbourhood name, locality name, region name, Australia');
     t.end();
@@ -91,14 +91,14 @@ module.exports.tests.australia = function(test, common) {
     var doc = {
       'name': { 'default': 'locality name' },
       'layer': 'locality',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'locality name, region name, Australia');
     t.end();
@@ -108,13 +108,13 @@ module.exports.tests.australia = function(test, common) {
     var doc = {
       'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'localadmin name, region name, Australia');
     t.end();
@@ -124,12 +124,12 @@ module.exports.tests.australia = function(test, common) {
     var doc = {
       'name': { 'default': 'county name' },
       'layer': 'county',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'county name, region name, Australia');
     t.end();
@@ -139,11 +139,11 @@ module.exports.tests.australia = function(test, common) {
     var doc = {
       'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'macrocounty name, region name, Australia');
     t.end();
@@ -153,10 +153,10 @@ module.exports.tests.australia = function(test, common) {
     var doc = {
       'name': { 'default': 'region name' },
       'layer': 'region',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'region name, Australia');
     t.end();
@@ -166,9 +166,9 @@ module.exports.tests.australia = function(test, common) {
     var doc = {
       'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
-      'macroregion': 'macroregion name',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'macroregion': ['macroregion name'],
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'macroregion name, Australia');
     t.end();
@@ -179,8 +179,8 @@ module.exports.tests.australia = function(test, common) {
       'name': { 'default': 'Australia' },
       'layer': 'country',
       'postalcode': 'postalcode',
-      'country_a': 'AUS',
-      'country': 'Australia'
+      'country_a': ['AUS'],
+      'country': ['Australia']
     };
     t.equal(generator(doc),'Australia');
     t.end();

--- a/test/labelGenerator_CAN.js
+++ b/test/labelGenerator_CAN.js
@@ -16,16 +16,16 @@ module.exports.tests.canada = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'venue name, locality name, region abbr, Canada');
     t.end();
@@ -37,16 +37,16 @@ module.exports.tests.canada = function(test, common) {
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'house number street name, locality name, region abbr, Canada');
     t.end();
@@ -56,16 +56,16 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'neighbourhood name, locality name, region abbr, Canada');
     t.end();
@@ -75,15 +75,15 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'locality name' },
       'layer': 'locality',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'locality name, region abbr, Canada');
     t.end();
@@ -93,14 +93,14 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'localadmin name, region abbr, Canada');
     t.end();
@@ -110,13 +110,13 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'county name' },
       'layer': 'county',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'county name, region abbr, Canada');
     t.end();
@@ -126,12 +126,12 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'macrocounty name, region abbr, Canada');
     t.end();
@@ -141,11 +141,11 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'region name' },
       'layer': 'region',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'region name, Canada');
     t.end();
@@ -155,9 +155,9 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'macroregion name, Canada');
     t.end();
@@ -167,8 +167,8 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'Canada' },
       'layer': 'country',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'Canada');
     t.end();
@@ -178,14 +178,14 @@ module.exports.tests.canada = function(test, common) {
     var doc = {
       'name': { 'default': 'locality name' },
       'layer': 'region',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'locality name, region name, Canada', 'region should be used');
     t.end();

--- a/test/labelGenerator_GBR.js
+++ b/test/labelGenerator_GBR.js
@@ -16,15 +16,15 @@ module.exports.tests.united_kingdom = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'venue name, locality name, macroregion name, United Kingdom');
     t.end();
@@ -36,14 +36,14 @@ module.exports.tests.united_kingdom = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'neighbourhood': ['neighbourhood name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'venue name, localadmin name, macroregion name, United Kingdom');
     t.end();
@@ -55,15 +55,15 @@ module.exports.tests.united_kingdom = function(test, common) {
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'house number street name, locality name, macroregion name, United Kingdom');
     t.end();
@@ -73,15 +73,15 @@ module.exports.tests.united_kingdom = function(test, common) {
     var doc = {
       'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'neighbourhood name, locality name, macroregion name, United Kingdom');
     t.end();
@@ -91,14 +91,14 @@ module.exports.tests.united_kingdom = function(test, common) {
     var doc = {
       'name': { 'default': 'locality name' },
       'layer': 'locality',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'locality name, macroregion name, United Kingdom');
     t.end();
@@ -108,13 +108,13 @@ module.exports.tests.united_kingdom = function(test, common) {
     var doc = {
       'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'localadmin name, macroregion name, United Kingdom');
     t.end();
@@ -124,12 +124,12 @@ module.exports.tests.united_kingdom = function(test, common) {
     var doc = {
       'name': { 'default': 'county name' },
       'layer': 'county',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'county name, macroregion name, United Kingdom');
     t.end();
@@ -139,11 +139,11 @@ module.exports.tests.united_kingdom = function(test, common) {
     var doc = {
       'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'macrocounty name, macroregion name, United Kingdom');
     t.end();
@@ -153,10 +153,10 @@ module.exports.tests.united_kingdom = function(test, common) {
     var doc = {
       'name': { 'default': 'region name' },
       'layer': 'region',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'region name, macroregion name, United Kingdom');
     t.end();
@@ -166,9 +166,9 @@ module.exports.tests.united_kingdom = function(test, common) {
     var doc = {
       'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
-      'macroregion': 'macroregion name',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'macroregion': ['macroregion name'],
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'macroregion name, United Kingdom');
     t.end();
@@ -179,8 +179,8 @@ module.exports.tests.united_kingdom = function(test, common) {
       'name': { 'default': 'United Kingdom' },
       'layer': 'country',
       'postalcode': 'postalcode',
-      'country_a': 'GBR',
-      'country': 'United Kingdom'
+      'country_a': ['GBR'],
+      'country': ['United Kingdom']
     };
     t.equal(generator(doc),'United Kingdom');
     t.end();

--- a/test/labelGenerator_USA.js
+++ b/test/labelGenerator_USA.js
@@ -16,16 +16,16 @@ module.exports.tests.united_states = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'venue name, locality name, region abbr, USA');
     t.end();
@@ -37,15 +37,15 @@ module.exports.tests.united_states = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'neighbourhood': ['neighbourhood name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'venue name, localadmin name, region abbr, USA');
     t.end();
@@ -57,14 +57,14 @@ module.exports.tests.united_states = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'neighbourhood': ['neighbourhood name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'venue name, county name, region abbr, USA');
     t.end();
@@ -76,16 +76,16 @@ module.exports.tests.united_states = function(test, common) {
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'house number street name, locality name, region abbr, USA');
     t.end();
@@ -95,16 +95,16 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'neighbourhood name, locality name, region abbr, USA');
     t.end();
@@ -114,17 +114,17 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'venue name' },
       'layer': 'borough',
-      'neighbourhood': 'neighbourhood name',
-      'borough': 'borough name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'neighbourhood': ['neighbourhood name'],
+      'borough': ['borough name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'venue name, borough name, locality name, region abbr, USA');
     t.end();
@@ -134,15 +134,15 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'locality name' },
       'layer': 'locality',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'locality name, region abbr, USA');
     t.end();
@@ -152,14 +152,14 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'localadmin name, region abbr, USA');
     t.end();
@@ -169,13 +169,13 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'county name' },
       'layer': 'county',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'county name, region abbr, USA');
     t.end();
@@ -185,12 +185,12 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
-      'macrocounty': 'macrocounty name',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'macrocounty name, region abbr, USA');
     t.end();
@@ -200,11 +200,11 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'region name' },
       'layer': 'region',
-      'region_a': 'region abbr',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'region name, USA');
     t.end();
@@ -214,9 +214,9 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'macroregion name, USA');
     t.end();
@@ -226,8 +226,8 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'United States' },
       'layer': 'country',
-      'country_a': 'USA',
-      'country': 'United States'
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'United States');
     t.end();
@@ -236,14 +236,14 @@ module.exports.tests.united_states = function(test, common) {
   test('region should be used when region_a is not available', function(t) {
     var doc = {
       'name': { 'default': 'locality name' },
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'locality name, region name, USA', 'region should be used');
     t.end();
@@ -253,10 +253,10 @@ module.exports.tests.united_states = function(test, common) {
     var doc = {
       'name': { 'default': 'dependency name' },
       'layer': 'dependency',
-      'dependency_a': 'dependency abbr',
-      'dependency': 'dependency name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'dependency_a': ['dependency abbr'],
+      'dependency': ['dependency name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'dependency name', 'dependency should be used');
     t.end();
@@ -266,16 +266,16 @@ module.exports.tests.united_states = function(test, common) {
   test('dependency abbreviation should be used instead of dependency name or country and skip region', function(t) {
     var doc = {
       'name': { 'default': 'locality name' },
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'dependency_a': 'dependency abbr',
-      'dependency': 'dependency name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'dependency_a': ['dependency abbr'],
+      'dependency': ['dependency name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'locality name, dependency abbr', 'dependency_a should be used');
     t.end();
@@ -285,15 +285,15 @@ module.exports.tests.united_states = function(test, common) {
   test('dependency name should be used instead of country when dep abbr is unavailable and skip region', function(t) {
     var doc = {
       'name': { 'default': 'locality name' },
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'dependency': 'dependency name',
-      'country_a': 'USA',
-      'country': 'United States'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'dependency': ['dependency name'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'locality name, dependency name', 'dependency should be used');
     t.end();

--- a/test/labelGenerator_default.js
+++ b/test/labelGenerator_default.js
@@ -16,15 +16,15 @@ module.exports.tests.default_country = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'venue name, locality name, country name');
     t.end();
@@ -36,14 +36,14 @@ module.exports.tests.default_country = function(test, common) {
       'layer': 'venue',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'neighbourhood': ['neighbourhood name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'venue name, localadmin name, country name');
     t.end();
@@ -55,15 +55,15 @@ module.exports.tests.default_country = function(test, common) {
       'layer': 'address',
       'housenumber': 'house number',
       'street': 'street name',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'house number street name, locality name, country name');
     t.end();
@@ -73,15 +73,15 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'neighbourhood name' },
       'layer': 'neighbourhood',
-      'neighbourhood': 'neighbourhood name',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'neighbourhood name, locality name, country name');
     t.end();
@@ -91,14 +91,14 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'locality name' },
       'layer': 'locality',
-      'locality': 'locality name',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'locality name, country name');
     t.end();
@@ -108,13 +108,13 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'localadmin name' },
       'layer': 'localadmin',
-      'localadmin': 'localadmin name',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'localadmin name, country name');
     t.end();
@@ -124,12 +124,12 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'county name' },
       'layer': 'county',
-      'county': 'county name',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'county name, country name');
     t.end();
@@ -139,11 +139,11 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'macrocounty name' },
       'layer': 'macrocounty',
-      'macrocounty': 'macrocounty name',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'macrocounty name, country name');
     t.end();
@@ -153,10 +153,10 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'region name' },
       'layer': 'region',
-      'region': 'region name',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'region name, country name');
     t.end();
@@ -166,9 +166,9 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'macroregion name' },
       'layer': 'macroregion',
-      'macroregion': 'macroregion name',
-      'country_a': 'country code',
-      'country': 'country name'
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
     };
     t.equal(generator(doc),'macroregion name, country name');
     t.end();
@@ -178,8 +178,8 @@ module.exports.tests.default_country = function(test, common) {
     var doc = {
       'name': { 'default': 'source country name' },
       'layer': 'country',
-      'country_a': 'country code',
-      'country': 'hierarchy country name'
+      'country_a': ['country code'],
+      'country': ['hierarchy country name']
     };
     t.equal(generator(doc),'hierarchy country name');
     t.end();

--- a/test/labelGenerator_examples.js
+++ b/test/labelGenerator_examples.js
@@ -16,12 +16,12 @@ module.exports.tests.canada = function(test, common) {
       'layer': 'venue',
       'housenumber': '1',
       'street': 'Main St',
-      'neighbourhood': 'College Heights',
-      'locality': 'Thunder Bay',
-      'region_a': 'ON',
-      'region': 'Ontario',
-      'country_a': 'CAN',
-      'country': 'Canada'
+      'neighbourhood': ['College Heights'],
+      'locality': ['Thunder Bay'],
+      'region_a': ['ON'],
+      'region': ['Ontario'],
+      'country_a': ['CAN'],
+      'country': ['Canada']
     };
     t.equal(generator(doc),'Tim Horton\'s, Thunder Bay, ON, Canada');
     t.end();
@@ -32,12 +32,12 @@ module.exports.tests.canada = function(test, common) {
       'name': { 'default': '1 Main St'},
       'layer': 'venue',
       'housenumber': '1',
-      'street': 'Main St',
-      'locality': 'Truth or Consequences',
-      'region_a': 'NM',
-      'region': 'New Mexico',
-      'country_a': 'USA',
-      'country': 'United States'
+      'street': ['Main St'],
+      'locality': ['Truth or Consequences'],
+      'region_a': ['NM'],
+      'region': ['New Mexico'],
+      'country_a': ['USA'],
+      'country': ['United States']
     };
     t.equal(generator(doc),'1 Main St, Truth or Consequences, NM, USA');
     t.end();
@@ -49,11 +49,11 @@ module.exports.tests.france = function(test, common) {
     var doc = {
       'name': { 'default': 'Tour Eiffel'},
       'layer': 'venue',
-      'neighbourhood': 'Quartier du Gros-Caillou',
-      'locality': 'Paris',
-      'region': 'Paris',
-      'country_a': 'FRA',
-      'country': 'France'
+      'neighbourhood': ['Quartier du Gros-Caillou'],
+      'locality': ['Paris'],
+      'region': ['Paris'],
+      'country_a': ['FRA'],
+      'country': ['France']
     };
     t.equal(generator(doc),'Tour Eiffel, Paris, France');
     t.end();
@@ -64,12 +64,12 @@ module.exports.tests.france = function(test, common) {
       'name': { 'default': '74 rue de rivoli'},
       'layer': 'address',
       'housenumber': '74',
-      'street': 'Rue de Rivoli',
-      'neighbourhood': 'Quartier Saint-Merri',
-      'locality': 'Paris',
-      'region': 'Paris',
-      'country_a': 'FRA',
-      'country': 'France'
+      'street': ['Rue de Rivoli'],
+      'neighbourhood': ['Quartier Saint-Merri'],
+      'locality': ['Paris'],
+      'region': ['Paris'],
+      'country_a': ['FRA'],
+      'country': ['France']
     };
     t.equal(generator(doc),'74 rue de rivoli, Paris, France');
     t.end();
@@ -79,11 +79,11 @@ module.exports.tests.france = function(test, common) {
     var doc = {
       'name': { 'default': 'Grange aux Belles Terrage'},
       'layer': 'neighbourhood',
-      'neighbourhood': 'Grange aux Belles Terrage',
-      'locality': 'Paris',
-      'region': 'Paris',
-      'country_a': 'FRA',
-      'country': 'France'
+      'neighbourhood': ['Grange aux Belles Terrage'],
+      'locality': ['Paris'],
+      'region': ['Paris'],
+      'country_a': ['FRA'],
+      'country': ['France']
     };
     t.equal(generator(doc),'Grange aux Belles Terrage, Paris, France');
     t.end();
@@ -93,9 +93,9 @@ module.exports.tests.france = function(test, common) {
     var doc = {
       'name': { 'default': 'Luxembourg'},
       'layer': 'locality',
-      'locality': 'Luxembourg',
-      'country_a': 'LUX',
-      'country': 'Luxembourg'
+      'locality': ['Luxembourg'],
+      'country_a': ['LUX'],
+      'country': ['Luxembourg']
     };
     // console.error(generator(doc));
     t.equal(generator(doc),'Luxembourg, Luxembourg');


### PR DESCRIPTION
Moving label assignment to pre-geojsonify means that the admin values are in arrays not scalars as before.  