### PR TITLE
Fix 500 errors by handling missing country_a

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,9 +1,22 @@
 {
   "node": true,
   "curly": true,
-  "latedef": true,
-  "quotmark": true,
+  "eqeqeq": true,
+  "esversion": 6,
+  "freeze": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": false,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonbsp": true,
+  "nonew": true,
+  "plusplus": false,
+  "quotmark": "single",
   "undef": true,
   "unused": false,
-  "trailing": true
+  "maxparams": 4,
+  "maxdepth": 4,
+  "maxlen": 140
 }

--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -46,11 +46,15 @@ function isGeonamesOrWhosOnFirst(source) {
 
 }
 
+function isInUSAOrCAN(record) {
+  return record.country_a && isUSAOrCAN(record.country_a[0]);
+}
+
 // helper function that sets a default label for non-US/CA regions and countries
 function getInitialLabel(record) {
   if (isRegion(record.layer) &&
       isGeonamesOrWhosOnFirst(record.source) &&
-      isUSAOrCAN(record.country_a[0])) {
+      isInUSAOrCAN(record)) {
     return [];
   }
 

--- a/test/labelGenerator_default.js
+++ b/test/labelGenerator_default.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var generator = require('../labelGenerator');
 
 module.exports.tests = {};
@@ -215,6 +217,17 @@ module.exports.tests.default_country = function(test, common) {
     t.end();
   });
 
+  test('region with no country_a handled gracefully', function(t) {
+    const doc = {
+      name: { default: 'region name' },
+      layer: 'region',
+      source: 'whosonfirst',
+      region: ['region name']
+      //note no country_a
+    };
+    t.equal(generator(doc),'region name');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
The code assumed that all records have a country_a value that is an
array with one element. They _should_ all meet this condition, but of
course data errors mean that some won't.