### PR TITLE
Faster travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,7 @@ matrix:
 env:
   global:
     - BUILD_LEADER_ID=2
-    - CXX=g++-4.8
 script: npm run travis
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 before_install:
   - npm i -g npm@^3.0.0
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   fast_finish: true
 env:
   global:
+    - BUILD_LEADER_ID=2
     - CXX=g++-4.8
 script: npm run travis
 addons:
@@ -22,4 +23,5 @@ before_install:
 before_script:
   - npm prune
 after_success:
-  - npm run semantic-release
+  - npm install -g npx
+  - npx -p node@8 npm run semantic-release


### PR DESCRIPTION
Now that TravisCI [defaults to Ubuntu 14](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status), we no longer need to install a newer version of GCC in our Travis builds.

This installation process can take up to 2 minutes (and our builds are usually under 4 minutes), meaning this change makes Travis run twice as fast!!

Connects pelias/pelias#575