### PR TITLE
[WIP] Add Korean label schema

### DIFF
--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -1,5 +1,7 @@
-var _ = require('lodash');
-var schemas = require('./labelSchema');
+'use strict';
+
+const _ = require('lodash');
+const schemas = require('./labelSchema');
 
 function dedupeNameAndFirstLabelElement(labelParts) {
   // only dedupe if a result has more than a name (the first label part)
@@ -7,10 +9,26 @@ function dedupeNameAndFirstLabelElement(labelParts) {
     // first, dedupe the name and 1st label array elements
     //  this is used to ensure that the `name` and first admin hierarchy elements aren't repeated
     //  eg - `["Lancaster", "Lancaster", "PA", "United States"]` -> `["Lancaster", "PA", "United States"]`
-    var deduped = _.uniq([labelParts.shift(), labelParts.shift()]);
-
+    const deduped = _.uniq([labelParts.shift(), labelParts.shift()]);
     // second, unshift the deduped parts back onto the labelParts
     labelParts.unshift.apply(labelParts, deduped);
+
+  }
+
+  return labelParts;
+
+}
+
+function dedupeNameAndLastLabelElement(labelParts) {
+  // only dedupe if a result has more than a name (the first label part)
+  if (labelParts.length > 1) {
+    // first, dedupe the name and second to last label array elements
+    //  this is used to ensure that the `name` and most granular admin hierarchy elements aren't repeated
+    //  eg - `["South Korea", "Seoul", "Seoul"]` -> `["South Korea", "Seoul"]`
+    const deduped = _.uniq([labelParts.pop(), labelParts.pop()]).reverse();
+
+    // second, unshift the deduped parts back onto the labelParts
+    labelParts.push.apply(labelParts, deduped);
 
   }
 
@@ -37,6 +55,14 @@ function isRegion(layer) {
   return 'region' === layer;
 }
 
+function isAddress(layer) {
+  return 'address' === layer;
+}
+
+function isKOR(country_a) {
+  return 'KOR' === country_a;
+}
+
 function isUSAOrCAN(country_a) {
   return 'USA' === country_a || 'CAN' === country_a;
 }
@@ -50,11 +76,15 @@ function isInUSAOrCAN(record) {
   return record.country_a && isUSAOrCAN(record.country_a[0]);
 }
 
+function isInKOR(record) {
+  return record.country_a && isKOR(record.country_a[0]);
+}
+
 // helper function that sets a default label for non-US/CA regions and countries
-function getInitialLabel(record) {
+function buildPrefixLabelParts(schema, record) {
   if (isRegion(record.layer) &&
-      isGeonamesOrWhosOnFirst(record.source) &&
-      isInUSAOrCAN(record)) {
+    isGeonamesOrWhosOnFirst(record.source) &&
+    isInUSAOrCAN(record)) {
     return [];
   }
 
@@ -62,26 +92,70 @@ function getInitialLabel(record) {
     return [];
   }
 
+  if (isInKOR(record)) {
+    return [];
+  }
+
   return [record.name.default];
 
 }
 
-module.exports = function( record ){
-  var schema = getSchema(record.country_a);
-
-  // in virtually all cases, this will be the `name` field
-  var labelParts = getInitialLabel(record);
+function buildAdminLabelPart(schema, record) {
+  let labelParts = [];
 
   // iterate the schema
-  for (var field in schema) {
-    var valueFunction = schema[field];
+  for (const field in schema.valueFunctions) {
+    const valueFunction = schema.valueFunctions[field];
     labelParts.push(valueFunction(record));
   }
+
+  return labelParts;
+}
+
+function buildPostfixLabelParts(schema, record) {
+  if (!isInKOR(record)) {
+    return [];
+  }
+
+  let labelParts = [];
+
+  if (isAddress(record.layer)) {
+    if (record.street) {
+      labelParts.push(record.street);
+    }
+    else if (record.neighbourhood) {
+      labelParts.push(record.neighbourhood);
+    }
+    labelParts.push(record.housenumber);
+
+    return labelParts;
+  }
+
+  return [record.name.default];
+}
+
+module.exports = function( record ){
+  const schema = getSchema(record.country_a);
+  const separator = _.get(schema, ['meta','separator'], ', ');
+
+  // in virtually all cases, this will be the `name` field
+  const prefixParts = buildPrefixLabelParts(schema, record);
+  const adminParts = buildAdminLabelPart(schema, record);
+  const postfixParts = buildPostfixLabelParts(schema, record);
+
+  let labelParts = _.concat(prefixParts, adminParts, postfixParts);
 
   // retain only things that are truthy
   labelParts = _.compact(labelParts);
 
   // third, dedupe and join with a comma and return
-  return dedupeNameAndFirstLabelElement(labelParts).join(', ');
+  if (isInKOR(record)) {
+    labelParts = dedupeNameAndLastLabelElement(labelParts);
+  }
+  else {
+    labelParts = dedupeNameAndFirstLabelElement(labelParts);
+  }
+
+  return labelParts.join(separator);
 
 };

--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -117,7 +117,7 @@ function buildPostfixLabelParts(schema, record) {
     return [];
   }
 
-  let labelParts = [];
+  const labelParts = [];
 
   if (isAddress(record.layer)) {
     if (record.street) {

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -105,8 +105,7 @@ module.exports = {
     'valueFunctions': {
       'country': getFirstProperty(['country']),
       'province': getFirstProperty(['region']),
-      'city': getFirstProperty(['county']),
-      'precinct': getFirstProperty(['locality', 'localadmin'])
+      'city': getFirstProperty(['county'])
     },
     'meta': {
       'separator': ' '

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -104,8 +104,9 @@ module.exports = {
   'KOR': {
     'valueFunctions': {
       'country': getFirstProperty(['country']),
-      'regional': getFirstProperty(['region']),
-      'local': getFirstProperty(['locality', 'localadmin', 'county'])
+      'province': getFirstProperty(['region']),
+      'city': getFirstProperty(['county']),
+      'precinct': getFirstProperty(['locality', 'localadmin', 'neighbourhood'])
     },
     'meta': {
       'separator': ' '

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -104,8 +104,8 @@ module.exports = {
   'KOR': {
     'valueFunctions': {
       'country': getFirstProperty(['country']),
-      'regional': getRegionalValue,
-      'local': getFirstProperty(['locality', 'localadmin', 'county', 'neighbourhood'])
+      'regional': getFirstProperty(['region']),
+      'local': getFirstProperty(['locality', 'localadmin', 'county'])
     },
     'meta': {
       'separator': ' '

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -106,7 +106,7 @@ module.exports = {
       'country': getFirstProperty(['country']),
       'province': getFirstProperty(['region']),
       'city': getFirstProperty(['county']),
-      'precinct': getFirstProperty(['locality', 'localadmin', 'neighbourhood'])
+      'precinct': getFirstProperty(['locality', 'localadmin'])
     },
     'meta': {
       'separator': ' '

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -67,28 +67,48 @@ function getUSADependencyOrCountryValue(record) {
 
 module.exports = {
   'default': {
-    'local': getFirstProperty(['locality', 'localadmin']),
-    'country': getFirstProperty(['dependency', 'country'])
+    'valueFunctions': {
+      'local': getFirstProperty(['locality', 'localadmin']),
+      'country': getFirstProperty(['dependency', 'country'])
+    }
   },
   'GBR': {
-    'local': getFirstProperty(['locality', 'localadmin']),
-    'regional': getFirstProperty(['macroregion']),
-    'country': getFirstProperty(['dependency', 'country'])
+    'valueFunctions': {
+      'local': getFirstProperty(['locality', 'localadmin']),
+      'regional': getFirstProperty(['macroregion']),
+      'country': getFirstProperty(['dependency', 'country'])
+    }
   },
   'USA': {
-    'borough': getFirstProperty(['borough']),
-    'local': getFirstProperty(['locality', 'localadmin', 'county']),
-    'regional': getRegionalValue,
-    'country': getUSADependencyOrCountryValue
+    'valueFunctions': {
+      'borough': getFirstProperty(['borough']),
+      'local': getFirstProperty(['locality', 'localadmin', 'county']),
+      'regional': getRegionalValue,
+      'country': getUSADependencyOrCountryValue
+    }
   },
   'AUS': {
-    'local' : getFirstProperty(['locality', 'localadmin']),
-    'regional' : getRegionalValue,
-    'country': getFirstProperty(['dependency', 'country'])
+    'valueFunctions': {
+      'local': getFirstProperty(['locality', 'localadmin']),
+      'regional': getRegionalValue,
+      'country': getFirstProperty(['dependency', 'country'])
+    }
   },
   'CAN': {
-    'local': getFirstProperty(['locality']), // no localadmins in CAN
-    'regional': getRegionalValue,
-    'country': getFirstProperty(['country'])
+    'valueFunctions': {
+      'local': getFirstProperty(['locality']), // no localadmins in CAN
+      'regional': getRegionalValue,
+      'country': getFirstProperty(['country'])
+    }
+  },
+  'KOR': {
+    'valueFunctions': {
+      'country': getFirstProperty(['country']),
+      'regional': getRegionalValue,
+      'local': getFirstProperty(['locality', 'localadmin', 'county', 'neighbourhood'])
+    },
+    'meta': {
+      'separator': ' '
+    }
   }
 };

--- a/test/labelGenerator_KOR.js
+++ b/test/labelGenerator_KOR.js
@@ -1,0 +1,195 @@
+var generator = require('../labelGenerator');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface', function(t) {
+    t.equal(typeof generator, 'function', 'valid function');
+    t.end();
+  });
+};
+
+module.exports.tests.united_states = function(test, common) {
+  // test('venue', function(t) {
+  //   var doc = {
+  //     'name': { 'default': 'venue name' },
+  //     'layer': 'venue',
+  //     'housenumber': 'house number',
+  //     'street': 'street name',
+  //     'neighbourhood': ['neighbourhood name'],
+  //     'locality': ['locality name'],
+  //     'localadmin': ['localadmin name'],
+  //     'county': ['county name'],
+  //     'macrocounty': ['macrocounty name'],
+  //     'region_a': ['region abbr'],
+  //     'region': ['region name'],
+  //     'macroregion': ['macroregion name'],
+  //     'country_a': ['KOR'],
+  //     'country': ['South Korea']
+  //   };
+  //   t.equal(generator(doc),'venue name, South Korea region name locality name');
+  //   t.end();
+  // });
+  //
+  // test('county value should be used when there is no locality', function(t) {
+  //   var doc = {
+  //     'name': { 'default': 'venue name' },
+  //     'layer': 'venue',
+  //     'housenumber': 'house number',
+  //     'street': 'street name',
+  //     'neighbourhood': ['neighbourhood name'],
+  //     'localadmin': ['localadmin name'],
+  //     'county': ['county name'],
+  //     'macrocounty': ['macrocounty name'],
+  //     'region_a': ['region abbr'],
+  //     'region': ['region name'],
+  //     'macroregion': ['macroregion name'],
+  //     'country_a': ['KOR'],
+  //     'country': ['South Korea']
+  //   };
+  //   t.equal(generator(doc),'venue name, South Korea region name county name');
+  //   t.end();
+  // });
+
+  test('address', function(t) {
+    var doc = {
+      'name': { 'default': '123 street name' },
+      'layer': 'address',
+      'housenumber': '123',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'region': ['region name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name locality name street name 123');
+    t.end();
+  });
+
+  // test('address: county value should be used when there is no locality or localadmin', function(t) {
+  //   var doc = {
+  //     'name': { 'default': '123 street name' },
+  //     'layer': 'address',
+  //     'housenumber': '123',
+  //     'street': 'street name',
+  //     'county': ['county name'],
+  //     'region': ['region name'],
+  //     'country_a': ['KOR'],
+  //     'country': ['South Korea']
+  //   };
+  //   t.equal(generator(doc),'South Korea region name county name street name 123');
+  //   t.end();
+  // });
+  //
+  // test('address: localadmin should be used when no locality', function(t) {
+  //   var doc = {
+  //     'name': { 'default': 'house number street name' },
+  //     'layer': 'address',
+  //     'housenumber': '123',
+  //     'street': 'street name',
+  //     'neighbourhood': ['neighbourhood name'],
+  //     'localadmin': ['localadmin name'],
+  //     'county': ['county name'],
+  //     'region': ['region name'],
+  //     'country_a': ['KOR'],
+  //     'country': ['South Korea']
+  //   };
+  //   t.equal(generator(doc),'South Korea region name locality name street name 123');
+  //   t.end();
+  // });
+
+  test('neighbourhood', function(t) {
+    var doc = {
+      'name': { 'default': 'neighbourhood name' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'region': ['region name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name locality name neighbourhood name');
+    t.end();
+  });
+
+  test('locality', function(t) {
+    var doc = {
+      'name': { 'default': 'locality name' },
+      'layer': 'locality',
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'region': ['region name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name locality name');
+    t.end();
+  });
+
+  test('localadmin', function(t) {
+    var doc = {
+      'name': { 'default': 'localadmin name' },
+      'layer': 'localadmin',
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'region': ['region name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name localadmin name');
+    t.end();
+  });
+
+  test('county', function(t) {
+    var doc = {
+      'name': { 'default': 'county name' },
+      'layer': 'county',
+      'county': ['county name'],
+      'region': ['region name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name county name');
+    t.end();
+  });
+
+  test('region', function(t) {
+    var doc = {
+      'name': { 'default': 'region name' },
+      'layer': 'region',
+      'region': ['region name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name');
+    t.end();
+  });
+
+  test('country', function(t) {
+    var doc = {
+      'name': { 'default': 'South Korea' },
+      'layer': 'country',
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('label generator (KOR): ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/labelGenerator_KOR.js
+++ b/test/labelGenerator_KOR.js
@@ -9,49 +9,28 @@ module.exports.tests.interface = function(test, common) {
   });
 };
 
-module.exports.tests.united_states = function(test, common) {
-  // test('venue', function(t) {
-  //   var doc = {
-  //     'name': { 'default': 'venue name' },
-  //     'layer': 'venue',
-  //     'housenumber': 'house number',
-  //     'street': 'street name',
-  //     'neighbourhood': ['neighbourhood name'],
-  //     'locality': ['locality name'],
-  //     'localadmin': ['localadmin name'],
-  //     'county': ['county name'],
-  //     'macrocounty': ['macrocounty name'],
-  //     'region_a': ['region abbr'],
-  //     'region': ['region name'],
-  //     'macroregion': ['macroregion name'],
-  //     'country_a': ['KOR'],
-  //     'country': ['South Korea']
-  //   };
-  //   t.equal(generator(doc),'venue name, South Korea region name locality name');
-  //   t.end();
-  // });
-  //
-  // test('county value should be used when there is no locality', function(t) {
-  //   var doc = {
-  //     'name': { 'default': 'venue name' },
-  //     'layer': 'venue',
-  //     'housenumber': 'house number',
-  //     'street': 'street name',
-  //     'neighbourhood': ['neighbourhood name'],
-  //     'localadmin': ['localadmin name'],
-  //     'county': ['county name'],
-  //     'macrocounty': ['macrocounty name'],
-  //     'region_a': ['region abbr'],
-  //     'region': ['region name'],
-  //     'macroregion': ['macroregion name'],
-  //     'country_a': ['KOR'],
-  //     'country': ['South Korea']
-  //   };
-  //   t.equal(generator(doc),'venue name, South Korea region name county name');
-  //   t.end();
-  // });
+module.exports.tests.south_korea = function(test, common) {
+  test('venue', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'venue',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name county name venue name');
+    t.end();
+  });
 
-  test('address: county value should be used when there is no locality or localadmin', function(t) {
+  test('address', function(t) {
     var doc = {
       'name': { 'default': '123 street name' },
       'layer': 'address',
@@ -66,7 +45,7 @@ module.exports.tests.united_states = function(test, common) {
     t.end();
   });
 
-  test('address: localadmin should be used when no locality', function(t) {
+  test('address should always use county even if locality and localadmin are available', function(t) {
     var doc = {
       'name': { 'default': 'house number street name' },
       'layer': 'address',
@@ -79,7 +58,7 @@ module.exports.tests.united_states = function(test, common) {
       'country_a': ['KOR'],
       'country': ['South Korea']
     };
-    t.equal(generator(doc),'South Korea region name county name localadmin name street name 123');
+    t.equal(generator(doc),'South Korea region name county name street name 123');
     t.end();
   });
 
@@ -95,7 +74,7 @@ module.exports.tests.united_states = function(test, common) {
       'country_a': ['KOR'],
       'country': ['South Korea']
     };
-    t.equal(generator(doc),'South Korea region name county name locality name neighbourhood name');
+    t.equal(generator(doc),'South Korea region name county name neighbourhood name');
     t.end();
   });
 
@@ -180,7 +159,7 @@ module.exports.tests.united_states = function(test, common) {
       'street': '모세로',
       'country': ['한국']
     };
-    t.equal(generator(doc),'한국 서울 용산구 서울 모세로 27');
+    t.equal(generator(doc),'한국 서울 용산구 모세로 27');
     t.end();
   });
 };

--- a/test/labelGenerator_KOR.js
+++ b/test/labelGenerator_KOR.js
@@ -51,55 +51,37 @@ module.exports.tests.united_states = function(test, common) {
   //   t.end();
   // });
 
-  test('address', function(t) {
+  test('address: county value should be used when there is no locality or localadmin', function(t) {
     var doc = {
       'name': { 'default': '123 street name' },
       'layer': 'address',
       'housenumber': '123',
       'street': 'street name',
+      'county': ['county name'],
+      'region': ['region name'],
+      'country_a': ['KOR'],
+      'country': ['South Korea']
+    };
+    t.equal(generator(doc),'South Korea region name county name street name 123');
+    t.end();
+  });
+
+  test('address: localadmin should be used when no locality', function(t) {
+    var doc = {
+      'name': { 'default': 'house number street name' },
+      'layer': 'address',
+      'housenumber': '123',
+      'street': 'street name',
       'neighbourhood': ['neighbourhood name'],
-      'locality': ['locality name'],
       'localadmin': ['localadmin name'],
       'county': ['county name'],
       'region': ['region name'],
       'country_a': ['KOR'],
       'country': ['South Korea']
     };
-    t.equal(generator(doc),'South Korea region name locality name street name 123');
+    t.equal(generator(doc),'South Korea region name localadmin name street name 123');
     t.end();
   });
-
-  // test('address: county value should be used when there is no locality or localadmin', function(t) {
-  //   var doc = {
-  //     'name': { 'default': '123 street name' },
-  //     'layer': 'address',
-  //     'housenumber': '123',
-  //     'street': 'street name',
-  //     'county': ['county name'],
-  //     'region': ['region name'],
-  //     'country_a': ['KOR'],
-  //     'country': ['South Korea']
-  //   };
-  //   t.equal(generator(doc),'South Korea region name county name street name 123');
-  //   t.end();
-  // });
-  //
-  // test('address: localadmin should be used when no locality', function(t) {
-  //   var doc = {
-  //     'name': { 'default': 'house number street name' },
-  //     'layer': 'address',
-  //     'housenumber': '123',
-  //     'street': 'street name',
-  //     'neighbourhood': ['neighbourhood name'],
-  //     'localadmin': ['localadmin name'],
-  //     'county': ['county name'],
-  //     'region': ['region name'],
-  //     'country_a': ['KOR'],
-  //     'country': ['South Korea']
-  //   };
-  //   t.equal(generator(doc),'South Korea region name locality name street name 123');
-  //   t.end();
-  // });
 
   test('neighbourhood', function(t) {
     var doc = {
@@ -179,6 +161,26 @@ module.exports.tests.united_states = function(test, common) {
       'country': ['South Korea']
     };
     t.equal(generator(doc),'South Korea');
+    t.end();
+  });
+
+  test('full address', function (t) {
+    var doc = {
+      'layer': 'address',
+      'name': { 'default': '27 모세로' },
+      'label': ['한국 서울 모세로 27'],
+      'county': ['용산구'],
+      'continent': ['아시아'],
+      'housenumber': '27',
+      'postalcode': ['14230'],
+      'region': ['서울'],
+      'country_a': ['KOR'],
+      'neighbourhood': ['구로본동'],
+      'locality': ['서울'],
+      'street': '모세로',
+      'country': ['한국']
+    };
+    t.equal(generator(doc),'한국 서울 서울 모세로 27');
     t.end();
   });
 };

--- a/test/labelGenerator_KOR.js
+++ b/test/labelGenerator_KOR.js
@@ -79,7 +79,7 @@ module.exports.tests.united_states = function(test, common) {
       'country_a': ['KOR'],
       'country': ['South Korea']
     };
-    t.equal(generator(doc),'South Korea region name localadmin name street name 123');
+    t.equal(generator(doc),'South Korea region name county name localadmin name street name 123');
     t.end();
   });
 
@@ -95,7 +95,7 @@ module.exports.tests.united_states = function(test, common) {
       'country_a': ['KOR'],
       'country': ['South Korea']
     };
-    t.equal(generator(doc),'South Korea region name locality name neighbourhood name');
+    t.equal(generator(doc),'South Korea region name county name locality name neighbourhood name');
     t.end();
   });
 
@@ -110,7 +110,7 @@ module.exports.tests.united_states = function(test, common) {
       'country_a': ['KOR'],
       'country': ['South Korea']
     };
-    t.equal(generator(doc),'South Korea region name locality name');
+    t.equal(generator(doc),'South Korea region name county name locality name');
     t.end();
   });
 
@@ -124,7 +124,7 @@ module.exports.tests.united_states = function(test, common) {
       'country_a': ['KOR'],
       'country': ['South Korea']
     };
-    t.equal(generator(doc),'South Korea region name localadmin name');
+    t.equal(generator(doc),'South Korea region name county name localadmin name');
     t.end();
   });
 
@@ -180,7 +180,7 @@ module.exports.tests.united_states = function(test, common) {
       'street': '모세로',
       'country': ['한국']
     };
-    t.equal(generator(doc),'한국 서울 서울 모세로 27');
+    t.equal(generator(doc),'한국 서울 용산구 서울 모세로 27');
     t.end();
   });
 };

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -28,7 +28,7 @@ module.exports.tests.supported_countries = function(test, common) {
     t.equals(Object.keys(schemas.CAN.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.GBR.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.AUS.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.KOR.valueFunctions).length, 3);
+    t.equals(Object.keys(schemas.KOR.valueFunctions).length, 4);
     t.equals(Object.keys(schemas.default.valueFunctions).length, 2);
 
     t.equals(Object.keys(schemas.KOR.meta).length, 1);

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -24,15 +24,15 @@ module.exports.tests.supported_countries = function(test, common) {
     t.notEquals(supported_countries.indexOf('default'), -1);
     t.equals(supported_countries.length, 6);
 
-    t.equals(Object.keys(schemas.USA).valueFunctions.length, 4);
-    t.equals(Object.keys(schemas.CAN).valueFunctions.length, 3);
-    t.equals(Object.keys(schemas.GBR).valueFunctions.length, 3);
-    t.equals(Object.keys(schemas.AUS).valueFunctions.length, 3);
-    t.equals(Object.keys(schemas.KOR).valueFunctions.length, 3);
+    t.equals(Object.keys(schemas.USA.valueFunctions).length, 4);
+    t.equals(Object.keys(schemas.CAN.valueFunctions).length, 3);
+    t.equals(Object.keys(schemas.GBR.valueFunctions).length, 3);
+    t.equals(Object.keys(schemas.AUS.valueFunctions).length, 3);
+    t.equals(Object.keys(schemas.KOR.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.default.valueFunctions).length, 2);
 
-    t.equals(Object.keys(schemas.KOR).meta.length, 1);
-    t.equals(Object.keys(schemas.KOR).meta.separator, ' ');
+    t.equals(Object.keys(schemas.KOR.meta).length, 1);
+    t.equals(schemas.KOR.meta.separator, ' ');
 
     t.end();
 

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -1,4 +1,6 @@
-var schemas = require('../labelSchema');
+'use strict';
+
+const schemas = require('../labelSchema');
 
 module.exports.tests = {};
 
@@ -12,20 +14,25 @@ module.exports.tests.interface = function(test, common) {
 
 module.exports.tests.supported_countries = function(test, common) {
   test('supported countries', function(t) {
-    var supported_countries = Object.keys(schemas);
+    const supported_countries = Object.keys(schemas);
 
     t.notEquals(supported_countries.indexOf('USA'), -1);
     t.notEquals(supported_countries.indexOf('CAN'), -1);
     t.notEquals(supported_countries.indexOf('GBR'), -1);
     t.notEquals(supported_countries.indexOf('AUS'), -1);
+    t.notEquals(supported_countries.indexOf('KOR'), -1);
     t.notEquals(supported_countries.indexOf('default'), -1);
-    t.equals(supported_countries.length, 5);
+    t.equals(supported_countries.length, 6);
 
-    t.equals(Object.keys(schemas.USA).length, 4);
-    t.equals(Object.keys(schemas.CAN).length, 3);
-    t.equals(Object.keys(schemas.GBR).length, 3);
-    t.equals(Object.keys(schemas.AUS).length, 3);
-    t.equals(Object.keys(schemas.default).length, 2);
+    t.equals(Object.keys(schemas.USA).valueFunctions.length, 4);
+    t.equals(Object.keys(schemas.CAN).valueFunctions.length, 3);
+    t.equals(Object.keys(schemas.GBR).valueFunctions.length, 3);
+    t.equals(Object.keys(schemas.AUS).valueFunctions.length, 3);
+    t.equals(Object.keys(schemas.KOR).valueFunctions.length, 3);
+    t.equals(Object.keys(schemas.default.valueFunctions).length, 2);
+
+    t.equals(Object.keys(schemas.KOR).meta.length, 1);
+    t.equals(Object.keys(schemas.KOR).meta.separator, ' ');
 
     t.end();
 
@@ -38,7 +45,7 @@ module.exports.all = function (tape, common) {
     return tape('schemas: ' + name, testFunction);
   }
 
-  for( var testCase in module.exports.tests ){
+  for( const testCase in module.exports.tests ){
     module.exports.tests[testCase](test, common);
   }
 };

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -28,7 +28,7 @@ module.exports.tests.supported_countries = function(test, common) {
     t.equals(Object.keys(schemas.CAN.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.GBR.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.AUS.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.KOR.valueFunctions).length, 4);
+    t.equals(Object.keys(schemas.KOR.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.default.valueFunctions).length, 2);
 
     t.equals(Object.keys(schemas.KOR.meta).length, 1);

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,7 @@ var tests = [
   require ('./labelGenerator_examples'),
   require ('./labelGenerator_GBR'),
   require ('./labelGenerator_USA'),
+  require ('./labelGenerator_KOR'),
   require ('./labelSchema')
 ];
 


### PR DESCRIPTION
Korean labels are written in descending order of granularity, like:
`country region county street housenumber`
Spaces (` `) are used as separators instead of the comma we're accustomed to in English-speaking countries.