### PR TITLE
Add French overseas label case

### DIFF
--- a/labelSchema.js
+++ b/labelSchema.js
@@ -1,5 +1,8 @@
 var _ = require('lodash');
 
+// French Guiana, Guadeloupe, Martinique, Reunion, Mayotte
+const FRA_OVERSEAS = ['GF', 'GP', 'MQ', 'RE', 'YT'];
+
 // find the first field of record that has a non-empty value that's not already in labelParts
 function getFirstProperty(fields) {
   return function(record) {
@@ -65,6 +68,21 @@ function getUSADependencyOrCountryValue(record) {
   return record.country_a[0];
 }
 
+// this function generates the last field of the labels for FRA records
+// 1.  use the region name if the record is a in the French overseas, eg - Saint-Denis, Reunion
+// 2.  use dependency name if not null
+// 3.  use country name, eg - Paris, France
+function getFRACountryValue() {
+  const _overseas = getFirstProperty(['region', 'dependency', 'country']);
+  const _default = getFirstProperty(['dependency', 'country']);
+  return (record) => {
+    if (!_.isEmpty(record.region_a) && _.includes(FRA_OVERSEAS, record.region_a[0])) {
+      return _overseas(record);
+    }
+    return _default(record);
+  };
+}
+
 module.exports = {
   'default': {
     'valueFunctions': {
@@ -109,6 +127,12 @@ module.exports = {
     },
     'meta': {
       'separator': ' '
+    }
+  },
+  'FRA': {
+    'valueFunctions': {
+      'local': getFirstProperty(['locality', 'localadmin']),
+      'country': getFRACountryValue()
     }
   }
 };

--- a/test/labelGenerator_FRA.js
+++ b/test/labelGenerator_FRA.js
@@ -1,0 +1,392 @@
+var generator = require('../labelGenerator');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface', function(t) {
+    t.equal(typeof generator, 'function', 'valid function');
+    t.end();
+  });
+};
+
+module.exports.tests.united_kingdom = function(test, common) {
+  test('venue', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'venue',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'venue name, locality name, France');
+    t.end();
+  });
+
+  test('overseas: venue', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'venue',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['RE'],
+      'region': ['Reunion'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'venue name, locality name, Reunion');
+    t.end();
+  });
+
+  test('localadmin value should be used when locality is not available', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'venue',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'venue name, localadmin name, France');
+    t.end();
+  });
+
+  test('overseas: localadmin value should be used when locality is not available', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'venue',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['RE'],
+      'region': ['Reunion'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'venue name, localadmin name, Reunion');
+    t.end();
+  });
+
+  test('street', function(t) {
+    var doc = {
+      'name': { 'default': 'house number street name' },
+      'layer': 'address',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'house number street name, locality name, France');
+    t.end();
+  });
+
+  test('overseas: street', function(t) {
+    var doc = {
+      'name': { 'default': 'house number street name' },
+      'layer': 'address',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['MQ'],
+      'region': ['Martinique'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'house number street name, locality name, Martinique');
+    t.end();
+  });
+
+  test('neighbourhood', function(t) {
+    var doc = {
+      'name': { 'default': 'neighbourhood name' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'neighbourhood name, locality name, France');
+    t.end();
+  });
+
+  test('overseas: neighbourhood', function(t) {
+    var doc = {
+      'name': { 'default': 'neighbourhood name' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['MQ'],
+      'region': ['Martinique'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'neighbourhood name, locality name, Martinique');
+    t.end();
+  });
+
+  test('locality', function(t) {
+    var doc = {
+      'name': { 'default': 'locality name' },
+      'layer': 'locality',
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'locality name, France');
+    t.end();
+  });
+
+  test('overseas: locality', function(t) {
+    var doc = {
+      'name': { 'default': 'locality name' },
+      'layer': 'locality',
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['GP'],
+      'region': ['Guadeloupe'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'locality name, Guadeloupe');
+    t.end();
+  });
+
+  test('localadmin', function(t) {
+    var doc = {
+      'name': { 'default': 'localadmin name' },
+      'layer': 'localadmin',
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'localadmin name, France');
+    t.end();
+  });
+
+  test('overseas: localadmin', function(t) {
+    var doc = {
+      'name': { 'default': 'localadmin name' },
+      'layer': 'localadmin',
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['GF'],
+      'region': ['French Guiana'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'localadmin name, French Guiana');
+    t.end();
+  });
+
+  test('county', function(t) {
+    var doc = {
+      'name': { 'default': 'county name' },
+      'layer': 'county',
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'county name, France');
+    t.end();
+  });
+
+  test('overseas: county', function(t) {
+    var doc = {
+      'name': { 'default': 'county name' },
+      'layer': 'county',
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['RE'],
+      'region': ['Reunion'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'county name, Reunion');
+    t.end();
+  });
+
+  test('macrocounty', function(t) {
+    var doc = {
+      'name': { 'default': 'macrocounty name' },
+      'layer': 'macrocounty',
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'macrocounty name, France');
+    t.end();
+  });
+
+  test('overseas: macrocounty', function(t) {
+    var doc = {
+      'name': { 'default': 'macrocounty name' },
+      'layer': 'macrocounty',
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['RE'],
+      'region': ['Reunion'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'macrocounty name, Reunion');
+    t.end();
+  });
+
+  test('region', function(t) {
+    var doc = {
+      'name': { 'default': 'region name' },
+      'layer': 'region',
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'region name, France');
+    t.end();
+  });
+
+  test('overseas: region', function(t) {
+    var doc = {
+      'name': { 'default': 'Reunion' },
+      'layer': 'region',
+      'region_a': ['RE'],
+      'region': ['Reunion'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'Reunion');
+    t.end();
+  });
+
+  test('macroregion', function(t) {
+    var doc = {
+      'name': { 'default': 'macroregion name' },
+      'layer': 'macroregion',
+      'macroregion': ['macroregion name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'macroregion name, France');
+    t.end();
+  });
+
+  test('dependency', function(t) {
+    var doc = {
+      'name': { 'default': 'dependency name' },
+      'layer': 'dependency',
+      'postalcode': 'postalcode',
+      'dependency': ['dependency name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'dependency name');
+    t.end();
+  });
+
+  test('country', function(t) {
+    var doc = {
+      'name': { 'default': 'France' },
+      'layer': 'country',
+      'postalcode': 'postalcode',
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'France');
+    t.end();
+  });
+
+  test('locality with dependency should ignore country', function(t) {
+    var doc = {
+      'name': { 'default': 'locality name' },
+      'layer': 'locality',
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'dependency': ['dependency name'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'locality name, dependency name');
+    t.end();
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('label generator (FRA): ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -21,14 +21,16 @@ module.exports.tests.supported_countries = function(test, common) {
     t.notEquals(supported_countries.indexOf('GBR'), -1);
     t.notEquals(supported_countries.indexOf('AUS'), -1);
     t.notEquals(supported_countries.indexOf('KOR'), -1);
+    t.notEquals(supported_countries.indexOf('FRA'), -1);
     t.notEquals(supported_countries.indexOf('default'), -1);
-    t.equals(supported_countries.length, 6);
+    t.equals(supported_countries.length, 7);
 
     t.equals(Object.keys(schemas.USA.valueFunctions).length, 4);
     t.equals(Object.keys(schemas.CAN.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.GBR.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.AUS.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.KOR.valueFunctions).length, 3);
+    t.equals(Object.keys(schemas.FRA.valueFunctions).length, 2);
     t.equals(Object.keys(schemas.default.valueFunctions).length, 2);
 
     t.equals(Object.keys(schemas.KOR.meta).length, 1);

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,7 @@ var tests = [
   require ('./labelGenerator_GBR'),
   require ('./labelGenerator_USA'),
   require ('./labelGenerator_KOR'),
+  require ('./labelGenerator_FRA'),
   require ('./labelSchema')
 ];
 


### PR DESCRIPTION
## Background

Overseas France (French: France d'outre-mer) consists of all the French-administered territories outside the European continent, mostly relics of the French colonial empire. These territories have varying legal status and different levels of autonomy. Among them, there are 5 regions (French: départements) that, when we want to display or search, we do not write `France`.

These regions are [`French Guiana`](https://spelunker.whosonfirst.org/id/85671195/), [`Guadeloupe`](https://spelunker.whosonfirst.org/id/85671209/), [`Martinique`](https://spelunker.whosonfirst.org/id/85671191/), [`Mayotte`](https://spelunker.whosonfirst.org/id/85671203/), [`Reunion`](https://spelunker.whosonfirst.org/id/85671199/).

## What can we do ?

For these regions only, we replace `France` by the region name. In everyday life, it's already what we do, when we want to write a letter in Overseas France, we put the name of the city and the region only (eg: `Saint-Benoît, Reunion`). 

By doing this, we also avoid some name collisions. We often have cities that have the same names in different regions (eg: [Saint-Denis, France](https://spelunker.whosonfirst.org/id/1159322261/) and [Saint-Denis, Reunion](https://spelunker.whosonfirst.org/id/404428927/), or [Saint-Joseph, Martinique](https://spelunker.whosonfirst.org/id/890444821/) and [Saint-Joseph, Reunion](https://spelunker.whosonfirst.org/id/890415455/)).
