### PR TITLE
Drop support for Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 8
   - 10
   - 12
 script: npm run travis

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Pelias label generation",
   "main": "labelGenerator.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "version": "0.0.0-development",
   "scripts": {


### PR DESCRIPTION
Node.js 8 is no longer supported as it reached [end of life](https://github.com/nodejs/Release#release-schedule) at the end of 2019.

Connects https://github.com/pelias/pelias/issues/837