### PR TITLE
NYC special case logic for address formatter

### DIFF
--- a/labelSchema.js
+++ b/labelSchema.js
@@ -120,6 +120,16 @@ function getNYCLocalValue(record) {
     _neighbourhood
   ) {
     return _neighbourhood;
+  } else if (_borough &&
+    _borough.startsWith('Manhattan')
+  ) {
+    // return 'Manhattan, New York, for Manhattan neighbourhoods
+    if (record.layer === 'neighbourhood') {
+      return `${_borough}, ${_default}`;
+    // return only locality for Manhattan venues/addresses
+    } else{
+      return _default;
+    }
   } else {
     return _borough || _default;
   }

--- a/test/labelGenerator_USA.js
+++ b/test/labelGenerator_USA.js
@@ -130,6 +130,132 @@ module.exports.tests.united_states = function(test, common) {
     t.end();
   });
 
+  test('venue in queens', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'borough',
+      'neighbourhood': ['Woodside'],
+      'borough': ['Queens'],
+      'locality': ['New York'],
+      'locality_a': ['NYC'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['NY'],
+      'region': ['New York'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'venue name, Woodside, NY, USA');
+    t.end();
+  });
+
+
+  test('venue in Brooklyn', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'borough',
+      'neighbourhood': ['Williamsburg'],
+      'borough': ['Brooklyn'],
+      'locality': ['New York'],
+      'locality_a': ['NYC'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['NY'],
+      'region': ['New York'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'venue name, Brooklyn, NY, USA');
+    t.end();
+  });
+
+  test('venue in Bronx', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'borough',
+      'neighbourhood': ['Mott Haven'],
+      'borough': ['Bronx'],
+      'locality': ['New York'],
+      'locality_a': ['NYC'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['NY'],
+      'region': ['New York'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'venue name, Bronx, NY, USA');
+    t.end();
+  });
+
+  test('neighbourhood', function(t) {
+    var doc = {
+      'name': { 'default': 'neighbourhood name' },
+      'layer': 'neighbourhood',
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['region abbr'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'neighbourhood name, locality name, region abbr, USA');
+    t.end();
+  });
+
+
+  test('neighbourhood in Queens', function(t) {
+    var doc = {
+      'name': { 'default': 'Rego Park' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['Rego Park'],
+      'borough': ['Queens'],
+      'locality': ['locality name'],
+      'locality_a': ['NYC'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['NY'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'Rego Park, Queens, NY, USA');
+    t.end();
+  });
+
+
+  test('neighbourhood in Brooklyn', function(t) {
+    var doc = {
+      'name': { 'default': 'Williamsburg' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['Williamsburg'],
+      'borough': ['Brooklyn'],
+      'locality': ['locality name'],
+      'locality_a': ['NYC'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region_a': ['NY'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'Williamsburg, Brooklyn, NY, USA');
+    t.end();
+  });
+
   test('locality', function(t) {
     var doc = {
       'name': { 'default': 'locality name' },

--- a/test/labelGenerator_USA.js
+++ b/test/labelGenerator_USA.js
@@ -113,7 +113,7 @@ module.exports.tests.united_states = function(test, common) {
   test('venue in borough', function(t) {
     var doc = {
       'name': { 'default': 'venue name' },
-      'layer': 'borough',
+      'layer': 'venue',
       'neighbourhood': ['neighbourhood name'],
       'borough': ['borough name'],
       'locality': ['locality name'],
@@ -133,7 +133,7 @@ module.exports.tests.united_states = function(test, common) {
   test('venue in queens', function(t) {
     var doc = {
       'name': { 'default': 'venue name' },
-      'layer': 'borough',
+      'layer': 'venue',
       'neighbourhood': ['Woodside'],
       'borough': ['Queens'],
       'locality': ['New York'],
@@ -155,7 +155,7 @@ module.exports.tests.united_states = function(test, common) {
   test('venue in Brooklyn', function(t) {
     var doc = {
       'name': { 'default': 'venue name' },
-      'layer': 'borough',
+      'layer': 'venue',
       'neighbourhood': ['Williamsburg'],
       'borough': ['Brooklyn'],
       'locality': ['New York'],
@@ -176,7 +176,7 @@ module.exports.tests.united_states = function(test, common) {
   test('venue in Bronx', function(t) {
     var doc = {
       'name': { 'default': 'venue name' },
-      'layer': 'borough',
+      'layer': 'venue',
       'neighbourhood': ['Mott Haven'],
       'borough': ['Bronx'],
       'locality': ['New York'],

--- a/test/labelGenerator_USA.js
+++ b/test/labelGenerator_USA.js
@@ -212,6 +212,44 @@ module.exports.tests.united_states = function(test, common) {
     t.end();
   });
 
+  test('venue in Manhattan', function(t) {
+    var doc = {
+      'name': { 'default': 'New York Bakery' },
+      'layer': 'venue',
+      'neighbourhood': ['Midtown'],
+      'borough': ['Manhattan'],
+      'locality': ['New York'],
+      'locality_a': ['NYC'],
+      'localadmin': ['New York'],
+      'county': ['New York'],
+      'region_a': ['NY'],
+      'region': ['New York'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'New York Bakery, New York, NY, USA');
+    t.end();
+  });
+
+  test('neighbourhood in Manhattan', function(t) {
+    var doc = {
+      'name': { 'default': 'Washington Heights' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['Washington Heights'],
+      'borough': ['Manhattan'],
+      'locality': ['New York'],
+      'locality_a': ['NYC'],
+      'localadmin': ['New York'],
+      'county': ['New York'],
+      'region_a': ['NY'],
+      'region': ['New York'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'Washington Heights, Manhattan, New York, NY, USA');
+    t.end();
+  });
+
   test('neighbourhood', function(t) {
     var doc = {
       'name': { 'default': 'neighbourhood name' },

--- a/test/labelGenerator_USA.js
+++ b/test/labelGenerator_USA.js
@@ -151,6 +151,24 @@ module.exports.tests.united_states = function(test, common) {
     t.end();
   });
 
+  test('neighbourhood in queens', function(t) {
+    var doc = {
+      'name': { 'default': 'Astoria' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['Astoria'],
+      'borough': ['Queens'],
+      'locality': ['New York'],
+      'locality_a': ['NYC'],
+      'localadmin': ['New York'],
+      'county': ['Queens'],
+      'region_a': ['NY'],
+      'region': ['New York'],
+      'country_a': ['USA'],
+      'country': ['United States']
+    };
+    t.equal(generator(doc),'Astoria, Queens, NY, USA');
+    t.end();
+  });
 
   test('venue in Brooklyn', function(t) {
     var doc = {


### PR DESCRIPTION
Hey, it's the NYC hacks! This is maybe the third time in my life I have written these. I don't know how else to do this except for a bunch of special case logic.

The comments + test cases I hope do a decent job of explaining what I'm trying to do here

  // NYC is special for addresses
  // - The borough is used for the locality in addresses
  // - Except in Queens, where ideally the neighbourhood is

    // We still want to return "neighborhood, borough, region_a" when a user searches for a neighborhood
    // otherwise it looks incomplete, so skip to returning the borough in that case
    // Otherwise, in Queens only, use the neighborhood for the city in address labels