### PR TITLE
default_region: add region_a to label where available

### DIFF
--- a/labelSchema.js
+++ b/labelSchema.js
@@ -46,6 +46,13 @@ function getRegionalValue(record) {
 
 }
 
+// return region_a unless record is a region itself
+function getRegionalAbbreviation(record) {
+  if ('region' !== record.layer && !_.isEmpty(record.region_a)) {
+    return _.first(record.region_a);
+  }
+}
+
 // this function generates the last field of the labels for US records
 // 1.  use dependency name if layer is dependency, eg - Puerto Rico
 // 2.  use country name if layer is country, eg - United States
@@ -150,6 +157,7 @@ module.exports = {
   'default': {
     'valueFunctions': {
       'local': getFirstProperty(['locality', 'localadmin']),
+      'regional': getRegionalAbbreviation,
       'country': getFirstProperty(['dependency', 'country'])
     }
   },

--- a/test/labelGenerator_default.js
+++ b/test/labelGenerator_default.js
@@ -24,11 +24,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'venue name, locality name, country name');
+    t.equal(generator(doc),'venue name, locality name, region abbrv, country name');
     t.end();
   });
 
@@ -43,11 +44,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'venue name, localadmin name, country name');
+    t.equal(generator(doc),'venue name, localadmin name, region abbrv, country name');
     t.end();
   });
 
@@ -63,11 +65,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'house number street name, locality name, country name');
+    t.equal(generator(doc),'house number street name, locality name, region abbrv, country name');
     t.end();
   });
 
@@ -81,11 +84,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'neighbourhood name, locality name, country name');
+    t.equal(generator(doc),'neighbourhood name, locality name, region abbrv, country name');
     t.end();
   });
 
@@ -98,11 +102,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'locality name, country name');
+    t.equal(generator(doc),'locality name, region abbrv, country name');
     t.end();
   });
 
@@ -114,11 +119,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'localadmin name, country name');
+    t.equal(generator(doc),'localadmin name, region abbrv, country name');
     t.end();
   });
 
@@ -129,11 +135,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'county name, country name');
+    t.equal(generator(doc),'county name, region abbrv, country name');
     t.end();
   });
 
@@ -143,11 +150,12 @@ module.exports.tests.default_country = function(test, common) {
       'layer': 'macrocounty',
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'macrocounty name, country name');
+    t.equal(generator(doc),'macrocounty name, region abbrv, country name');
     t.end();
   });
 
@@ -156,6 +164,7 @@ module.exports.tests.default_country = function(test, common) {
       'name': { 'default': 'region name' },
       'layer': 'region',
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -33,7 +33,7 @@ module.exports.tests.supported_countries = function(test, common) {
     t.equals(Object.keys(schemas.KOR.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.FRA.valueFunctions).length, 2);
     t.equals(Object.keys(schemas.ITA.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.default.valueFunctions).length, 2);
+    t.equals(Object.keys(schemas.default.valueFunctions).length, 3);
 
     t.equals(Object.keys(schemas.KOR.meta).length, 1);
     t.equals(schemas.KOR.meta.separator, ' ');


### PR DESCRIPTION
Using the `default` schema it's often difficult to distinguish localities with the same name in the same country, this makes selecting the correct result impossible:

<img width="318" alt="Screenshot 2021-02-04 at 23 11 07" src="https://user-images.githubusercontent.com/738069/106877996-506ebd00-673e-11eb-86fc-507a8f15b3d0.png">

In other cases it would be nice to see some more information about which general area of the country a place is in:

<img width="238" alt="Screenshot 2021-02-04 at 23 15 20" src="https://user-images.githubusercontent.com/738069/106878532-f1f60e80-673e-11eb-9268-cb61d947e410.png">

This PR adds the `region_a` value where available (except for the `region` layer itself, which would be redundant).

It's been this way for a very long time but I think this is an improvement, ideally I would like to see four things in the label:

```bash
{name}, {locality}, {region}, {country}
```

I looked at using the `region` label instead of `region_a` but it can generate some labels which sound repetitive like "Wellington, Wellington City" and "Chiang Mai, Chiang Mai".
