### PR TITLE
Add region to default labels if different from city 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "https://github.com/pelias/labels.git"
   },
   "dependencies": {
-    "lodash": "^4.16.4"
+    "lodash": "^4.16.4",
+    "remove-accents": "^0.4.2"
   },
   "devDependencies": {
     "difflet": "^1.0.1",

--- a/test/labelGenerator_default.js
+++ b/test/labelGenerator_default.js
@@ -24,11 +24,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'venue name, locality name, country name');
+    t.equal(generator(doc),'venue name, locality name, region abbrv, country name');
     t.end();
   });
 
@@ -43,11 +44,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'venue name, localadmin name, country name');
+    t.equal(generator(doc),'venue name, localadmin name, region abbrv, country name');
     t.end();
   });
 
@@ -63,11 +65,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'house number street name, locality name, country name');
+    t.equal(generator(doc),'house number street name, locality name, region abbrv, country name');
     t.end();
   });
 
@@ -81,11 +84,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'neighbourhood name, locality name, country name');
+    t.equal(generator(doc),'neighbourhood name, locality name, region abbrv, country name');
     t.end();
   });
 
@@ -98,6 +102,43 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
+    };
+    t.equal(generator(doc),'locality name, region abbrv, country name');
+    t.end();
+  });
+
+  test('locality for a major city with a region of the same name', function(t) {
+    var doc = {
+      'name': { 'default': 'locality name' },
+      'layer': 'locality',
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['locality name'], // same as locality
+      'region_a': ['region abbrv'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['country code'],
+      'country': ['country name']
+    };
+    t.equal(generator(doc),'locality name, country name');
+    t.end();
+  });
+
+  test('locality for a major city with a region of the same name, minor formatting differences', function(t) {
+    var doc = {
+      'name': { 'default': 'locality name' },
+      'layer': 'locality',
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['Locality nÁme'], // same as locality
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
@@ -114,11 +155,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'localadmin name, country name');
+    t.equal(generator(doc),'localadmin name, region abbrv, country name');
     t.end();
   });
 
@@ -129,11 +171,12 @@ module.exports.tests.default_country = function(test, common) {
       'county': ['county name'],
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'county name, country name');
+    t.equal(generator(doc),'county name, region abbrv, country name');
     t.end();
   });
 
@@ -143,11 +186,12 @@ module.exports.tests.default_country = function(test, common) {
       'layer': 'macrocounty',
       'macrocounty': ['macrocounty name'],
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']
     };
-    t.equal(generator(doc),'macrocounty name, country name');
+    t.equal(generator(doc),'macrocounty name, region abbrv, country name');
     t.end();
   });
 
@@ -156,6 +200,7 @@ module.exports.tests.default_country = function(test, common) {
       'name': { 'default': 'region name' },
       'layer': 'region',
       'region': ['region name'],
+      'region_a': ['region abbrv'],
       'macroregion': ['macroregion name'],
       'country_a': ['country code'],
       'country': ['country name']

--- a/test/labelGenerator_examples.js
+++ b/test/labelGenerator_examples.js
@@ -102,6 +102,48 @@ module.exports.tests.france = function(test, common) {
     t.end();
   });
 
+  test('São Paulo, major city in Brazil', function(t) {
+    const doc = {
+      'name': { 'default': 'São Paulo'},
+      'layer': 'locality',
+      'locality': ['São Paulo'],
+      'region': ['São Paulo'],
+      'region_a': ['SP'],
+      'country_a': ['BRA'],
+      'country': ['Brazil']
+    };
+    t.equal(generator(doc),'São Paulo, Brazil');
+    t.end();
+  });
+
+  test('São Paulo, major city in Brazil. Language set to English', function(t) {
+    const doc = {
+      'name': { 'default': 'São Paulo'},
+      'layer': 'locality',
+      'locality': ['São Paulo'],
+      'region': ['Sao Paulo'],
+      'region_a': ['SP'],
+      'country_a': ['BRA'],
+      'country': ['Brazil']
+    };
+    t.equal(generator(doc),'São Paulo, Brazil');
+    t.end();
+  });
+
+  test('São Paulo, Amazonas - small village in Brazil', function(t) {
+    const doc = {
+      'name': { 'default': 'São Paulo'},
+      'layer': 'locality',
+      'locality': ['São Paulo'],
+      'region': ['Amazonas'],
+      'region_a': ['AM'],
+      'country_a': ['BRA'],
+      'country': ['Brazil']
+    };
+    t.equal(generator(doc),'São Paulo, AM, Brazil');
+    t.end();
+  });
+
 };
 module.exports.tests.italy = function(test, common) {
   test('Italian street address', function(t) {

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -33,7 +33,6 @@ module.exports.tests.supported_countries = function(test, common) {
     t.equals(Object.keys(schemas.KOR.valueFunctions).length, 3);
     t.equals(Object.keys(schemas.FRA.valueFunctions).length, 2);
     t.equals(Object.keys(schemas.ITA.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.default.valueFunctions).length, 2);
 
     t.equals(Object.keys(schemas.KOR.meta).length, 1);
     t.equals(schemas.KOR.meta.separator, ' ');


### PR DESCRIPTION
This adds the region to the default labels, but only if the _region name_ is different from the _city name_ (defined as locality or localadmin name).

The intent is to handle major world cities like Berlin, Sao Paulo, Paris, etc that are contained within an administrative region of the same name, and are so well known that they do not require any additional specifiers.

In the more common case where the region and city names are different, the region abbreviation is preferred, with the region name being returned only if the abbreviation is not available.