### PR TITLE
Add Singapore schema without region or country

### DIFF
--- a/labelSchema.js
+++ b/labelSchema.js
@@ -244,5 +244,10 @@ module.exports = {
       'regional': getRegionalValue,
       'country': getFirstProperty(['country'])
     }
-  }
+  },
+  'SGP': {
+    'valueFunctions': {
+      'local': getFirstProperty(['locality'])
+    }
+  },
 };

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -247,7 +247,8 @@ module.exports = {
   },
   'SGP': {
     'valueFunctions': {
-      'local': getFirstProperty(['locality'])
+      'local': getFirstProperty(['microhood', 'neighbourhood']),
+      'country': getFirstProperty(['country'])
     }
   },
 };

--- a/test/labelGenerator_examples.js
+++ b/test/labelGenerator_examples.js
@@ -144,6 +144,19 @@ module.exports.tests.france = function(test, common) {
     t.end();
   });
 
+  test('National Gallery Singapore', function(t) {
+    const doc = {
+      'name': { 'default': 'National Gallery Singapore'},
+      'layer': 'venue',
+      'locality': ['Singapore'],
+      'region': ['Central Singapore'],
+      'region_a': ['CS'],
+      'country_a': ['SGP'],
+      'country': ['Singapore']
+    };
+    t.equal(generator(doc),'National Gallery Singapore, Singapore');
+    t.end();
+  });
 };
 module.exports.tests.italy = function(test, common) {
   test('Italian street address', function(t) {

--- a/test/labelGenerator_examples.js
+++ b/test/labelGenerator_examples.js
@@ -144,7 +144,7 @@ module.exports.tests.france = function(test, common) {
     t.end();
   });
 
-  test('National Gallery Singapore', function(t) {
+  test('National Gallery Singapore - WOF data format as of Feb. 2021', function(t) {
     const doc = {
       'name': { 'default': 'National Gallery Singapore'},
       'layer': 'venue',
@@ -155,6 +155,21 @@ module.exports.tests.france = function(test, common) {
       'country': ['Singapore']
     };
     t.equal(generator(doc),'National Gallery Singapore, Singapore');
+    t.end();
+  });
+
+  test('Universal Studios Singapore- glorious future WOF data structure', function(t) {
+    const doc = {
+      'name': { 'default': 'Universal Studios Singapore'},
+      'layer': 'venue',
+      'neighbourhood': ['Sentosa'],
+      'locality': ['Singapore'],
+      'region': ['Central Singapore'],
+      'region_a': ['CS'],
+      'country_a': ['SGP'],
+      'country': ['Singapore']
+    };
+    t.equal(generator(doc),'Universal Studios Singapore, Sentosa, Singapore');
     t.end();
   });
 };

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -24,7 +24,6 @@ module.exports.tests.supported_countries = function(test, common) {
     t.notEquals(supported_countries.indexOf('FRA'), -1);
     t.notEquals(supported_countries.indexOf('ITA'), -1);
     t.notEquals(supported_countries.indexOf('default'), -1);
-    t.equals(supported_countries.length, 8);
 
     t.equals(Object.keys(schemas.USA.valueFunctions).length, 4);
     t.equals(Object.keys(schemas.CAN.valueFunctions).length, 3);


### PR DESCRIPTION
This is a PR that should be merged after #43, where we add the `region` to most labels by default.

After looking at the changes from #43, it seems like Singapore is a case where the labels are significantly worse. While Singapore _does_ have [regions](https://en.wikipedia.org/wiki/Regions_of_Singapore), I could not find any references to them being included in most addresses under normal use.

Libpostal does not have any address format data, nor does Nominatim as far as I can tell.

Overall, since Singapore is both a city, and a country, I think the right thing to do is to only display Singapore once, without any region. That means the label code actually only looks at the `locality` value, not the `region` or even `country`. I suppose it could look at `country` but not `locality`, but I assume that will generally be equivalent.