### PR TITLE
fix for rare cases where country labels are blank

### DIFF
--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -88,7 +88,7 @@ function buildPrefixLabelParts(schema, record) {
     return [];
   }
 
-  if (isCountry(record.layer)) {
+  if (isCountry(record.layer) && !_.isEmpty(record.country)) {
     return [];
   }
 

--- a/test/labelGenerator_examples.js
+++ b/test/labelGenerator_examples.js
@@ -204,7 +204,21 @@ module.exports.tests.name_only = function(test, common) {
     t.equal(generator(doc),'Result name');
     t.end();
   });
+};
 
+// Geonames Philippines record has no admin info!
+// https://github.com/pelias/api/issues/720
+module.exports.tests.name_only_country = function (test, common) {
+  test('name-only results (no admin fields) - Geonames Philippines', function (t) {
+    var doc = {
+      'name': {
+        'default': 'Republic of the Philippines'
+      },
+      'layer': 'country'
+    };
+    t.equal(generator(doc), 'Republic of the Philippines');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This issue was closed today https://github.com/pelias/api/issues/720 but I noticed when [clicking the link](https://pelias.github.io/compare/#/v1/autocomplete?sources=geonames&text=phil) that we still have a rare labelling issue.

In the case where the record is a `country` *and* it has no admin info, we currently produce no label 😱 

<img width="311" alt="Screenshot 2021-06-09 at 12 16 28" src="https://user-images.githubusercontent.com/738069/121337336-87fda800-c970-11eb-862b-38726236e51b.png">

It's a very rare case, in fact this Geonames Philippines doc might be the only one, but this PR fixes it. 