### PR TITLE
Refactor label generation with a "label builder" function

### DIFF
--- a/builders/KOR.js
+++ b/builders/KOR.js
@@ -1,0 +1,74 @@
+const _ = require('lodash');
+
+function dedupeNameAndLastLabelElement(labelParts) {
+  // only dedupe if a result has more than a name (the first label part)
+  if (labelParts.length > 1) {
+    // first, dedupe the name and second to last label array elements
+    //  this is used to ensure that the `name` and most granular admin hierarchy elements aren't repeated
+    //  eg - `["South Korea", "Seoul", "Seoul"]` -> `["South Korea", "Seoul"]`
+    const deduped = _.uniq([labelParts.pop(), labelParts.pop()]).reverse();
+
+    // second, unshift the deduped parts back onto the labelParts
+    labelParts.push.apply(labelParts, deduped);
+
+  }
+
+  return labelParts;
+}
+
+function nameOrAddressComponents(schema, record) {
+  const labelParts = [];
+
+  // add the address/venue components
+  if (record.layer === 'address') {
+    if (record.street) {
+      labelParts.push(record.street);
+    }
+    else if (record.neighbourhood) {
+      labelParts.push(record.neighbourhood);
+    }
+    labelParts.push(record.housenumber);
+
+    return labelParts;
+  }
+
+  // support name aliases
+  if (Array.isArray(record.name.default)) {
+    return record.name.default.slice(0,1);
+  }
+
+  return [record.name.default];
+}
+
+function buildAdminLabelPart(schema, record) {
+  let labelParts = [];
+
+  // iterate the admin components in the schema
+  // the order of the properties in the file determine
+  // the order of elements in this arrayt
+  // For Korea, we start with the country and work backwards
+  for (const field in schema.valueFunctions) {
+    const valueFunction = schema.valueFunctions[field];
+    labelParts.push(valueFunction(record));
+  }
+
+  return labelParts;
+}
+
+// builds a complete label by combining several components
+// admin parts: administrative information like city
+// name or address parts: info on the actual record, like name or address
+function koreaBuilder(schema, record) {
+
+  const adminParts = buildAdminLabelPart(schema, record);
+  const nameorAddressParts = nameOrAddressComponents(schema, record);
+
+  let labelParts = _.concat(adminParts, nameorAddressParts);
+
+  // retain only things that are truthy
+  labelParts = _.compact(labelParts);
+
+  return dedupeNameAndLastLabelElement(labelParts);
+}
+
+module.exports = koreaBuilder;

--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -19,23 +19,6 @@ function dedupeNameAndFirstLabelElement(labelParts) {
 
 }
 
-function dedupeNameAndLastLabelElement(labelParts) {
-  // only dedupe if a result has more than a name (the first label part)
-  if (labelParts.length > 1) {
-    // first, dedupe the name and second to last label array elements
-    //  this is used to ensure that the `name` and most granular admin hierarchy elements aren't repeated
-    //  eg - `["South Korea", "Seoul", "Seoul"]` -> `["South Korea", "Seoul"]`
-    const deduped = _.uniq([labelParts.pop(), labelParts.pop()]).reverse();
-
-    // second, unshift the deduped parts back onto the labelParts
-    labelParts.push.apply(labelParts, deduped);
-
-  }
-
-  return labelParts;
-
-}
-
 function getSchema(country_a) {
   if (!_.isEmpty(schemas[country_a])) {
     return schemas[country_a[0]];
@@ -59,10 +42,6 @@ function isAddress(layer) {
   return 'address' === layer;
 }
 
-function isKOR(country_a) {
-  return 'KOR' === country_a;
-}
-
 function isUSAOrCAN(country_a) {
   return 'USA' === country_a || 'CAN' === country_a;
 }
@@ -76,10 +55,6 @@ function isInUSAOrCAN(record) {
   return record.country_a && isUSAOrCAN(record.country_a[0]);
 }
 
-function isInKOR(record) {
-  return record.country_a && isKOR(record.country_a[0]);
-}
-
 // helper function that sets a default label for non-US/CA regions and countries
 function buildPrefixLabelParts(schema, record) {
   if (isRegion(record.layer) &&
@@ -89,10 +64,6 @@ function buildPrefixLabelParts(schema, record) {
   }
 
   if (isCountry(record.layer) && !_.isEmpty(record.country)) {
-    return [];
-  }
-
-  if (isInKOR(record)) {
     return [];
   }
 
@@ -117,49 +88,21 @@ function buildAdminLabelPart(schema, record) {
   return labelParts;
 }
 
-function buildPostfixLabelParts(schema, record) {
-  if (!isInKOR(record)) {
-    return [];
-  }
-
-  const labelParts = [];
-
-  if (isAddress(record.layer)) {
-    if (record.street) {
-      labelParts.push(record.street);
-    }
-    else if (record.neighbourhood) {
-      labelParts.push(record.neighbourhood);
-    }
-    labelParts.push(record.housenumber);
-
-    return labelParts;
-  }
-
-  // support name aliases
-  if (Array.isArray(record.name.default)) {
-    return record.name.default.slice(0,1);
-  }
-
-  return [record.name.default];
-}
-
 // builds a complete label by combining several components
 // the parts generally follow this format
 // prefix parts: the venue name or address
 // admin parts: administrative information like city
-// postfix part: higher level admin areas
 function defaultBuilder(schema, record) {
 
   // in virtually all cases, this will be the `name` field
   const prefixParts = buildPrefixLabelParts(schema, record);
   const adminParts = buildAdminLabelPart(schema, record);
-  const postfixParts = buildPostfixLabelParts(schema, record);
 
-  const labelParts = _.concat(prefixParts, adminParts, postfixParts);
+  let labelParts = _.concat(prefixParts, adminParts);
 
   // retain only things that are truthy
-  return _.compact(labelParts);
+  labelParts =  _.compact(labelParts);
+  return dedupeNameAndFirstLabelElement(labelParts);
 }
 
 module.exports = function( record ){
@@ -169,14 +112,5 @@ module.exports = function( record ){
 
   let labelParts = builder(schema, record);
 
-  // third, dedupe and join with a comma and return
-  if (isInKOR(record)) {
-    labelParts = dedupeNameAndLastLabelElement(labelParts);
-  }
-  else {
-    labelParts = dedupeNameAndFirstLabelElement(labelParts);
-  }
-
   return labelParts.join(separator);
-
 };

--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -144,19 +144,30 @@ function buildPostfixLabelParts(schema, record) {
   return [record.name.default];
 }
 
-module.exports = function( record ){
-  const schema = getSchema(record.country_a);
-  const separator = _.get(schema, ['meta','separator'], ', ');
+// builds a complete label by combining several components
+// the parts generally follow this format
+// prefix parts: the venue name or address
+// admin parts: administrative information like city
+// postfix part: higher level admin areas
+function defaultBuilder(schema, record) {
 
   // in virtually all cases, this will be the `name` field
   const prefixParts = buildPrefixLabelParts(schema, record);
   const adminParts = buildAdminLabelPart(schema, record);
   const postfixParts = buildPostfixLabelParts(schema, record);
 
-  let labelParts = _.concat(prefixParts, adminParts, postfixParts);
+  const labelParts = _.concat(prefixParts, adminParts, postfixParts);
 
   // retain only things that are truthy
-  labelParts = _.compact(labelParts);
+  return _.compact(labelParts);
+}
+
+module.exports = function( record ){
+  const schema = getSchema(record.country_a);
+  const separator = _.get(schema, ['meta','separator'], ', ');
+  const builder = _.get(schema, ['meta', 'builder'], defaultBuilder);
+
+  let labelParts = builder(schema, record);
 
   // third, dedupe and join with a comma and return
   if (isInKOR(record)) {

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -229,7 +229,8 @@ module.exports = {
       'city': getFirstProperty(['county'])
     },
     'meta': {
-      'separator': ' '
+      'separator': ' ',
+      'builder': require('./builders/KOR')
     }
   },
   'FRA': {

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -33,7 +33,6 @@ module.exports.tests.supported_countries = function(test, common) {
     t.equals(Object.keys(schemas.FRA.valueFunctions).length, 2);
     t.equals(Object.keys(schemas.ITA.valueFunctions).length, 3);
 
-    t.equals(Object.keys(schemas.KOR.meta).length, 1);
     t.equals(schemas.KOR.meta.separator, ' ');
 
     t.end();


### PR DESCRIPTION
Our label generation logic has gotten a bit convoluted. While there's a good amount that can be handled only through configuration in a JSON structure, the actual code tries to handle all possible label formats in one place. Even with only a few general structures ("American"/"European" style, and "Korean" style), the code is already quite complex and confusing.

This PR is a pure refactoring that simplifies the existing logic, and introduces the idea of a "label builder" function that can be specified for any country, allowing more configuration for places that have unique address formats.

## How the current code works

Roughly, a label is built using 3 parts: prefix components, admin components, and postfix components.

Depending on the country, only one of the prefix components or postfix components are used.

For example, in many countries the housenumber/streetname come _before_ admin components like region or country, so they would be handled by the prefix components.

However, some countries have address formats that put admin info first (like Korea). These countries would not set any prefix components, and would instead add postfix components.

This is a reasonable system, but the logic was already getting quite complex: both the prefix and postfix component code have to have conditionals that depend on the country, making the actual code quite a bit less clear.

Worse, the system is still not _all_ that flexible: the code for prefix and postfix components has to handle any possible permutation of those elements that _any_ country might use.

Fortunately, we haven't added all that many label formats for different countries yet, but its clear doing so would not be sustainable with the current layout.

## How the code in this PR works

This PR allows for each country's label schema to define a "builder function" that constructs a label for that country however is best. There's a _default_ label builder that will be used if one isn't specified, and it works for the vast majority of American/European style addresses.

With this pattern, any single label builder can probably be quite simple. Both the default and the newly added Korean label builder are shorter, with fewer conditionals, than before.

## Future goals

This PR is meant to be a foundation from which we can define more address formats. In particular, I'd like to add address formats for Japan. Japan is unique in that it has address formats that vary for English and Japanese. It also tends to have lots of specific requirements for different regions, and even cities. Attempting to build all those different cases into generic code for the whole planet would be a bad idea.

For now, the only unique address builder is for a specific country, Korea. But I could easily see how we eventually find patterns for address formats that share commonalities across countries. For example, lots of countries in Eastern Europe or South America have very similar formats.