### PR TITLE
Initial Japanese Labels

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,6 +7,7 @@
   "immed": true,
   "indent": 2,
   "latedef": false,
+  "loopfunc": true,
   "newcap": true,
   "noarg": true,
   "noempty": true,

--- a/builders/JPN.js
+++ b/builders/JPN.js
@@ -1,0 +1,60 @@
+const _ = require('lodash');
+
+function buildPrimaryName(schema, record) {
+  if (Array.isArray(record.name.default)) {
+    return record.name.default.slice(0,1);
+  }
+
+  return [record.name.default];
+}
+
+// create a "normalized" version of a Japanese address part
+// do this by removing some portions of an admin area that should
+// otherwise be ignored for deduplication, like the "prefecture" suffix
+function normalizeJapaneseAdmin(input) {
+  const lower = input.toLowerCase();
+  return lower
+              .replace(/^(.*)-shi$/i, '$1')
+              .replace(/^(.*)\sprefecture$/i, '$1');
+}
+
+function buildAdminLabelPart(schema, record) {
+  let labelParts = [];
+
+  // iterate the admin components in the schema
+  // the order of the properties in the file determine
+  // the order of elements in this array
+  for (const field in schema.valueFunctions) {
+    const valueFunction = schema.valueFunctions[field];
+    const newName = valueFunction(record);
+
+    //check if this new name is a duplicate of any others, accounting for normalization
+    if (newName && !_.some(labelParts, (value) => normalizeJapaneseAdmin(value) === normalizeJapaneseAdmin(newName))) {
+      labelParts.push(newName);
+    }
+  }
+
+  return labelParts;
+}
+
+// builds a complete label by combining several components
+// the parts generally follow this format
+// name: the venue name or address
+// admin: administrative information like city
+function japanBuilder(schema, record) {
+
+  const nameParts = buildPrimaryName(schema, record);
+  const adminParts = buildAdminLabelPart(schema, record);
+
+  let labelParts = _.concat(nameParts, adminParts);
+
+  // retain only things that are truthy
+  labelParts =  _.compact(labelParts);
+
+  // remove exact duplicates or admin areas will have their name twice
+  labelParts = _.uniq(labelParts);
+
+  return labelParts;
+}
+
+module.exports = japanBuilder;

--- a/labelSchema.js
+++ b/labelSchema.js
@@ -252,4 +252,21 @@ module.exports = {
       'country': getFirstProperty(['country'])
     }
   },
+  'JPN': {
+    'valueFunctions': {
+      'district': getFirstProperty(['neighbourhood']),
+      'machi': getFirstProperty(['borough']), // this is a middle layer between city and district for larger cities
+      // 20 important cities in Japan are known as 'designated cities'
+      // https://en.wikipedia.org/wiki/Cities_designated_by_government_ordinance_of_Japan
+      'designated-city': getFirstProperty(['locality']),
+      // outside of designated cities, this is the city name
+      'city': getFirstProperty(['county']),
+      'prefecture': getFirstProperty(['region']),
+      'postalcode': getFirstProperty(['postalcode']),
+      'country': getFirstProperty(['country']),
+    },
+    'meta': {
+      'builder': require('./builders/JPN')
+    }
+  },
 };

--- a/test/labelGenerator_JPN.js
+++ b/test/labelGenerator_JPN.js
@@ -1,0 +1,124 @@
+const generator = require('../labelGenerator');
+
+module.exports.tests = {};
+
+module.exports.tests.english_style_labels = function(test, common) {
+  test('tokyo post office', function(t) {
+    const doc = {
+      name: { default: 'Tokyo Central Post Office' },
+      layer: 'venue',
+      housenumber: '2',
+      borough: ['Chiyoda'],
+      locality: ['Tokyo'],
+      county: ['Chiyoda'],
+      region: ['Tokyo'],
+      region_a: ['TK'],
+      postalcode: ['100-0005'],
+      country_a: ['JPN'],
+      country: ['Japan'],
+      continent: ['Asia'],
+    };
+    t.equal(generator(doc),'Tokyo Central Post Office, Chiyoda, Tokyo, 100-0005, Japan');
+    t.end();
+  });
+
+  test('tokyo address from OA', function(t) {
+    const doc = {
+      name: { default: '7-9 丸の内二丁目' },
+      layer: 'address',
+      housenumber: '7-9',
+      neighbourhood: ['Marunochi 2 Chome'],
+      borough: ['Chiyoda'],
+      locality: ['Tokyo'],
+      county: ['Chiyoda'],
+      region: ['Tokyo'],
+      region_a: ['TK'],
+      country: ['Japan'],
+      country_a: ['JPN'],
+      continent: ['Asia'],
+    };
+    t.equal(generator(doc),'7-9 丸の内二丁目, Marunochi 2 Chome, Chiyoda, Tokyo, Japan');
+    t.end();
+  });
+
+  test('Shizuoka (smaller city near Tokyo) example from OA', function(t) {
+    const doc = {
+      name: { default: '331-8 中原' },
+      layer: 'address',
+      housenumber: '331-8',
+      street: '中原',
+      // we should ideally have lower level admin info here, but we don't as of this writing
+      locality: ['Shizuoka-shi'],
+      county: ['Shizuoka'],
+      region: ['Shizuoka Prefecture'],
+      region_a: ['SZ'],
+      country: ['Japan'],
+      country_a: ['JPN'],
+      continent: ['Asia'],
+    };
+    t.equal(generator(doc),'331-8 中原, Shizuoka-shi, Japan');
+    t.end();
+  });
+
+  test('address in Sapporo from OA', function(t) {
+    const doc = {
+      name: { default: '2-12 北二十四条西四丁目' },
+      layer: 'address',
+      housenumber: '2-12',
+      street: '北二十四条西四丁目',
+      locality: ['Sapporo-shi'],
+      county: ['Sapporo'],
+      region: ['Hokkaido Prefecture'],
+      region_a: ['HK'],
+      country: ['Japan'],
+      country_a: ['JPN'],
+      continent: ['Asia'],
+    };
+    t.equal(generator(doc),'2-12 北二十四条西四丁目, Sapporo-shi, Hokkaido Prefecture, Japan');
+    t.end();
+  });
+
+  test('address outside of a designated city', function(t) {
+    const doc = {
+      name: { default: '1059-2 大崎' },
+      layer: 'address',
+      housenumber: '1059-2',
+      street: '大崎',
+      county: ['Ogori'],
+      region: ['Fukuoka Prefecture'],
+      region_a: ['FO'],
+      country: ['Japan'],
+      country_a: ['JPN'],
+      continent: ['Asia'],
+    };
+    t.equal(generator(doc),'1059-2 大崎, Ogori, Fukuoka Prefecture, Japan');
+    t.end();
+  });
+
+  test('neighbourhood admin area', function(t) {
+    const doc = {
+      name: { default: '９丁目' },
+      layer: 'neighbourhood',
+      neighbourhood: ['９丁目'],
+      locality: ['Umegaoka'],
+      county: ['Setagaya'],
+      region: ['Tokyo'],
+      region_a: ['TK'],
+      country: ['Japan'],
+      country_a: ['JPN'],
+      continent: ['Asia'],
+    };
+    t.equal(generator(doc),'９丁目, Umegaoka, Setagaya, Tokyo, Japan');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('label generator (JPN): ' + name, testFunction);
+  }
+
+  for( let testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,7 @@ var tests = [
   require ('./labelGenerator_GBR'),
   require ('./labelGenerator_USA'),
   require ('./labelGenerator_KOR'),
+  require ('./labelGenerator_JPN'),
   require ('./labelGenerator_FRA'),
   require ('./labelSchema')
 ];


### PR DESCRIPTION
This PR builds on #49 to improve labels for Japan.

Japanese addressing formats are quite complicated and vary from region to region. Also, there are distinctly different formats for when addresses are written in English (or, presumably, other European languages) versus Japanese. This PR is concerned with only the English address format variant.

For the most part, this PR works by adding all the relevant parent elements to the label, as described in the Wikipedia page for the [Japanese addressing system](https://en.wikipedia.org/wiki/Japanese_addressing_system). There's also a small bit of Japan-specific deduplication for label elements.

There are examples taken from our actual OSM and OpenAddresses data across Japan. Most of these examples are addresses, but POIs and admin areas are also included.