### PR TITLE
Language specific labels

### DIFF
--- a/getSchema.js
+++ b/getSchema.js
@@ -1,0 +1,18 @@
+const _ = require('lodash');
+
+const schemas = require('./labelSchema');
+
+module.exports = function getSchema(record, language) {
+  if (_.isEmpty(record)) { return schemas.default; }
+  if (_.isEmpty(record.country_a)) { return schemas.default; }
+
+  // handle either array or scalar country codes, normalizing to upper case
+  const country_code_value = _.isArray(record.country_a) ? record.country_a[0] : record.country_a;
+  const country_code = _.isString(country_code_value) ? country_code_value.toUpperCase() : undefined;
+
+  const language_code = _.isString(language) ? language.toUpperCase() : undefined;
+
+  const schema = _.get(schemas[country_code], `languages.${language_code}`) || schemas[country_code] || schemas.default;
+
+  return schema;
+};

--- a/labelGenerator.js
+++ b/labelGenerator.js
@@ -1,7 +1,6 @@
-'use strict';
-
 const _ = require('lodash');
-const schemas = require('./labelSchema');
+
+const getSchema = require('./getSchema');
 
 function dedupeNameAndFirstLabelElement(labelParts) {
   // only dedupe if a result has more than a name (the first label part)
@@ -16,16 +15,12 @@ function dedupeNameAndFirstLabelElement(labelParts) {
   }
 
   return labelParts;
-
 }
 
-function getSchema(country_a) {
-  if (!_.isEmpty(schemas[country_a])) {
-    return schemas[country_a[0]];
-  }
+function getLanguage(language) {
+  if (!_.isString(language)) { return; }
 
-  return schemas.default;
-
+  return language.toUpperCase();
 }
 
 // this can go away once geonames is no longer supported
@@ -105,12 +100,12 @@ function defaultBuilder(schema, record) {
   return dedupeNameAndFirstLabelElement(labelParts);
 }
 
-module.exports = function( record ){
-  const schema = getSchema(record.country_a);
+module.exports = function( record, language ){
+  const schema = getSchema(record, language);
   const separator = _.get(schema, ['meta','separator'], ', ');
   const builder = _.get(schema, ['meta', 'builder'], defaultBuilder);
 
   let labelParts = builder(schema, record);
 
-  return labelParts.join(separator);
+  return _.trim(labelParts.join(separator));
 };

--- a/test/getSchema.js
+++ b/test/getSchema.js
@@ -1,0 +1,82 @@
+const getSchema = require('../getSchema');
+const schemas = require('../labelSchema');
+
+module.exports.tests = {};
+
+module.exports.tests.schema_and_language_selection = function(test, common) {
+  test('no language and undefined record selects default schema', function(t) {
+    const actual = getSchema(undefined, undefined);
+    const expected = schemas['default'];
+
+    t.equals(actual, expected, 'default schema selected');
+    t.end();
+  });
+
+  test('no language and record with no country_a selects default schema', function(t) {
+    const actual = getSchema({}, undefined);
+    const expected = schemas['default'];
+
+    t.equals(actual, expected, 'default schema selected');
+    t.end();
+  });
+
+
+  test('no language and record with null country_a selects default schema', function(t) {
+    const actual = getSchema({ country_a: [ null ] }, undefined);
+    const expected = schemas['default'];
+
+    t.equals(actual, expected, 'default schema selected');
+    t.end();
+  });
+
+  test('no language and record with scalar country_a selects correct schema', function(t) {
+    const actual = getSchema({ country_a: 'usa' }, undefined);
+    const expected = schemas.USA;
+
+    t.equals(actual, expected, 'USA schema selected');
+    t.end();
+  });
+
+  test('invalid country_a selects default schema', function(t) {
+    const actual = getSchema({ country_a: ['XYZ']}, undefined);
+    const expected = schemas['default'];
+
+    t.equals(actual, expected, 'default schema selected');
+    t.end();
+  });
+
+  test('no language and record with array country_a selects correct schema', function(t) {
+    const actual = getSchema({ country_a: ['USA']}, undefined);
+    const expected = schemas.USA;
+
+    t.equals(actual, expected, 'USA schema selected');
+    t.end();
+  });
+
+  test('no language and record with lowercase country_a selects correct schema', function(t) {
+    const actual = getSchema({ country_a: ['usa']}, undefined);
+    const expected = schemas.USA;
+
+    t.equals(actual, expected, 'USA schema selected');
+    t.end();
+  });
+
+  test('valid but unspecified language and valid country_a selects correct schema', function(t) {
+    const actual = getSchema({ country_a: ['USA']}, 'ARA'); // no arabic custom format in USA
+    const expected = schemas.USA;
+
+    t.equals(actual, expected, 'USA schema selected');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('schemas: ' + name, testFunction);
+  }
+
+  for( const testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ var tests = [
   require ('./labelGenerator_KOR'),
   require ('./labelGenerator_JPN'),
   require ('./labelGenerator_FRA'),
+  require ('./getSchema'),
   require ('./labelSchema')
 ];
 


### PR DESCRIPTION
This PR sets up a system that allows label formats to vary depending on the _display language_ for a given request. It will therefore require some changes to pass that language into the label generator when it's called in the Pelias API.

Label formats for different languages can be configured by adding a new `labelSchema` element under the `languages` property.

Along with this functionality comes some significantly enhanced testing for the logic that decides which label format to use. It was already a bit messy and completely untested. With some new functionality it was definitely time for some tests!

[diff for just this PR](https://github.com/pelias/labels/compare/japanese-labels...language-specific-labels)