### PR TITLE
Add support for microstate Monaco

### DIFF
--- a/labelSchema.js
+++ b/labelSchema.js
@@ -239,6 +239,12 @@ module.exports = {
       'country': getFRACountryValue()
     }
   },
+  'MCO': {
+    'valueFunctions': {
+      'local': getFirstProperty(['neighbourhood']),
+      'country': getFirstProperty(['country'])
+    }
+  },
   'ITA': {
     'valueFunctions': {
       'local': getFirstProperty(['locality', 'localadmin']),

--- a/test/labelGenerator_MCO.js
+++ b/test/labelGenerator_MCO.js
@@ -1,0 +1,107 @@
+var generator = require('../labelGenerator');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface', function(t) {
+    t.equal(typeof generator, 'function', 'valid function');
+    t.end();
+  });
+};
+
+module.exports.tests.monaco = function(test, common) {
+  test('venue', function(t) {
+    var doc = {
+      'name': { 'default': 'venue name' },
+      'layer': 'venue',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['MCO'],
+      'country': ['Monaco']
+    };
+    t.equal(generator(doc),'venue name, neighbourhood name, Monaco');
+    t.end();
+  });
+
+  test('street', function(t) {
+    var doc = {
+      'name': { 'default': 'house number street name' },
+      'layer': 'address',
+      'housenumber': 'house number',
+      'street': 'street name',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['MCO'],
+      'country': ['Monaco']
+    };
+    t.equal(generator(doc),'house number street name, neighbourhood name, Monaco');
+    t.end();
+  });
+
+  test('neighbourhood', function(t) {
+    var doc = {
+      'name': { 'default': 'neighbourhood name' },
+      'layer': 'neighbourhood',
+      'neighbourhood': ['neighbourhood name'],
+      'locality': ['locality name'],
+      'localadmin': ['localadmin name'],
+      'county': ['county name'],
+      'macrocounty': ['macrocounty name'],
+      'region': ['region name'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['MCO'],
+      'country': ['Monaco']
+    };
+    t.equal(generator(doc),'neighbourhood name, Monaco');
+    t.end();
+  });
+
+  test('region', function(t) {
+    var doc = {
+      'name': { 'default': 'Monaco' },
+      'layer': 'region',
+      'region': ['Monaco'],
+      'macroregion': ['macroregion name'],
+      'country_a': ['MCO'],
+      'country': ['Monaco']
+    };
+    t.equal(generator(doc),'Monaco');
+    t.end();
+  });
+
+  test('country', function(t) {
+    var doc = {
+      'name': { 'default': 'Monaco' },
+      'layer': 'country',
+      'postalcode': 'postalcode',
+      'country_a': ['MCO'],
+      'country': ['Monaco']
+    };
+    t.equal(generator(doc),'Monaco');
+    t.end();
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('label generator (FRA): ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ var tests = [
   require ('./labelGenerator_JPN'),
   require ('./labelGenerator_JPN_JPN'),
   require ('./labelGenerator_FRA'),
+  require ('./labelGenerator_MCO'),
   require ('./getSchema'),
   require ('./labelSchema')
 ];


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

Monaco is a sovereign city-state and microstate, that means everything from locality to country are named Monaco. This causes a strange response from pelias (the first one):
[`/v1/autocomplete?sources=wof&lang=en&text=monaco`](https://pelias.github.io/compare/#/v1/autocomplete?lang=en&text=monaco)
```
0) Monaco, Monaco
1) Monaco, Monaco
2) Monaco, Nelson Airport, NE, New Zealand
3) Taverna del Monaco, AV, Italy
4) Cozzo del Monaco, CS, Italy
5) Bosco del Monaco, RO, Italy
6) Tour de Monaco, Mur-de-Barrez, France
7) Hôtel de Monaco, Vic-sur-Cère, France
8) Synagogue de Monaco, Monaco, Monaco
9) Prince's Palace of Monaco, Monaco, Monaco
```

---
#### Here's what actually got changed :clap:

For Monaco we display only the `neighbourhood` and `country`.

---
#### Here's how others can test the changes :eyes:

The previous response should display only `Monaco`

Some other example:
Before PR for [`Boulevard de belgique, Monaco`](https://pelias.github.io/compare/#/v1/autocomplete?lang=en&text=Boulevard+de+belgique%2C+Monaco)
```
0) Boulevard de Belgique, Monaco, Monaco
1) Boulevard de Belgique, Monaco, Monaco
2) Moneghetti, MC, Monaco
```
After the PR:
```
Boulevard de Belgique, La Condamine, Monaco
Boulevard de Belgique, Fontvieille, Monaco
Moneghetti, La Condamine, Monaco
```