### PR TITLE
ensure french regional postcodes have a "local" sublabel

### DIFF
--- a/labelSchema.js
+++ b/labelSchema.js
@@ -1,11 +1,9 @@
-var _ = require('lodash');
+const _ = require('lodash');
 const removeAccents = require('remove-accents');
 
 // lowercase characters and remove some punctuation
 function normalizeString(str){
-  if (!str) {
-    return '';
-  }
+  if (!str) { return ''; }
   return removeAccents(str.toLowerCase().split(/[ ,-]+/).join(' '));
 }
 
@@ -21,11 +19,8 @@ function getFirstProperty(fields) {
       if (!_.isEmpty(fieldValue)) {
         return fieldValue[0];
       }
-
     }
-
   };
-
 }
 
 // this function is exclusively used for figuring out which field to use for states/provinces
@@ -235,7 +230,7 @@ module.exports = {
   },
   'FRA': {
     'valueFunctions': {
-      'local': getFirstProperty(['locality', 'localadmin']),
+      'local': getFirstProperty(['locality', 'localadmin', 'county', 'macrocounty']),
       'country': getFRACountryValue()
     }
   },

--- a/test/labelGenerator_FRA.js
+++ b/test/labelGenerator_FRA.js
@@ -9,7 +9,7 @@ module.exports.tests.interface = function(test, common) {
   });
 };
 
-module.exports.tests.united_kingdom = function(test, common) {
+module.exports.tests.france = function(test, common) {
   test('venue', function(t) {
     var doc = {
       'name': { 'default': 'venue name' },
@@ -375,6 +375,37 @@ module.exports.tests.united_kingdom = function(test, common) {
       'country': ['France']
     };
     t.equal(generator(doc),'locality name, dependency name');
+    t.end();
+  });
+
+  test('postalcode with locality', function(t) {
+    var doc = {
+      'name': { 'default': '69001' },
+      'layer': 'postalcode',
+      'locality': ['Lyon'],
+      'county': ['Metropolitan Lyon'],
+      'macrocounty': ['Lyon'],
+      'region': ['Rhône'],
+      'macroregion': ['Auvergne-Rhone-Alpes'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'69001, Lyon, France');
+    t.end();
+  });
+
+  test('postalcode without locality or localadmin', function(t) {
+    var doc = {
+      'name': { 'default': '13080' },
+      'layer': 'postalcode',
+      'county': ['Aix-en-Provence Canton'],
+      'macrocounty': ['Aix-En-Provence'],
+      'region': ['Bouches-du-Rhône'],
+      'macroregion': ['Provence-Alpes-Cote d\'Azur'],
+      'country_a': ['FRA'],
+      'country': ['France']
+    };
+    t.equal(generator(doc),'13080, Aix-en-Provence Canton, France');
     t.end();
   });
 


### PR DESCRIPTION
In some cases French postcodes are simply listed as being in 'France'.

<img width="241" alt="Screenshot 2025-02-24 at 13 52 49" src="https://github.com/user-attachments/assets/8a59a910-c723-44b9-8e27-f33abe4ad6c1" />
