### PR TITLE
Remove useless/unclear/overspecified tests

### DIFF
--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -4,14 +4,6 @@ const schemas = require('../labelSchema');
 
 module.exports.tests = {};
 
-module.exports.tests.interface = function(test, common) {
-  test('interface', function(t) {
-    t.equal(typeof schemas, 'object', 'valid object');
-    t.equal(schemas.hasOwnProperty('default'), true, 'has default defined');
-    t.end();
-  });
-};
-
 module.exports.tests.supported_countries = function(test, common) {
   test('supported countries', function(t) {
     const supported_countries = Object.keys(schemas);

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -17,18 +17,7 @@ module.exports.tests.supported_countries = function(test, common) {
     t.ok(supported_countries.includes('ITA'));
     t.ok(supported_countries.includes('default'));
 
-    t.equals(Object.keys(schemas.USA.valueFunctions).length, 4);
-    t.equals(Object.keys(schemas.CAN.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.GBR.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.AUS.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.KOR.valueFunctions).length, 3);
-    t.equals(Object.keys(schemas.FRA.valueFunctions).length, 2);
-    t.equals(Object.keys(schemas.ITA.valueFunctions).length, 3);
-
-    t.equals(schemas.KOR.meta.separator, ' ');
-
     t.end();
-
   });
 };
 

--- a/test/labelSchema.js
+++ b/test/labelSchema.js
@@ -8,14 +8,14 @@ module.exports.tests.supported_countries = function(test, common) {
   test('supported countries', function(t) {
     const supported_countries = Object.keys(schemas);
 
-    t.notEquals(supported_countries.indexOf('USA'), -1);
-    t.notEquals(supported_countries.indexOf('CAN'), -1);
-    t.notEquals(supported_countries.indexOf('GBR'), -1);
-    t.notEquals(supported_countries.indexOf('AUS'), -1);
-    t.notEquals(supported_countries.indexOf('KOR'), -1);
-    t.notEquals(supported_countries.indexOf('FRA'), -1);
-    t.notEquals(supported_countries.indexOf('ITA'), -1);
-    t.notEquals(supported_countries.indexOf('default'), -1);
+    t.ok(supported_countries.includes('USA'));
+    t.ok(supported_countries.includes('CAN'));
+    t.ok(supported_countries.includes('GBR'));
+    t.ok(supported_countries.includes('AUS'));
+    t.ok(supported_countries.includes('KOR'));
+    t.ok(supported_countries.includes('FRA'));
+    t.ok(supported_countries.includes('ITA'));
+    t.ok(supported_countries.includes('default'));
 
     t.equals(Object.keys(schemas.USA.valueFunctions).length, 4);
     t.equals(Object.keys(schemas.CAN.valueFunctions).length, 3);


### PR DESCRIPTION
Some of the core tests for lables are a bit of a waste. I've removed or updated tests that do one of the following
- test basic structure ("interface" tests) that are obviously correct if other tests work
- Test something in an unclear way
- Overspecify implementation details, not actual behavior.

Nothing big, but this will help going forward :)